### PR TITLE
CMakeLists.txt: Remove -m64 in CMAKE_Fortran_FLAGS

### DIFF
--- a/glue-codes/fast-farm/5MW_Baseline/ServoData/DISCON/CMakeLists.txt
+++ b/glue-codes/fast-farm/5MW_Baseline/ServoData/DISCON/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 # Customizations for GNU Fortran compiler
 macro(set_gfortran)
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -m64 -ffree-line-length-none -fdefault-real-8 -C")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-none -fdefault-real-8 -C")
 
   # debug flags
   if(CMAKE_BUILD_TYPE MATCHES Debug)
@@ -37,7 +37,7 @@ endmacro(set_ifort)
 
 # Customizations for Intel Fortran Compiler on posix systems
 macro(set_ifort_posix)
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -m64 -fpp -real-size 64")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fpp -real-size 64")
 
   # debug flags
   if(CMAKE_BUILD_TYPE MATCHES Debug)

--- a/glue-codes/openfast/5MW_Baseline/ServoData/DISCON/CMakeLists.txt
+++ b/glue-codes/openfast/5MW_Baseline/ServoData/DISCON/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 # Customizations for GNU Fortran compiler
 macro(set_gfortran)
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -m64 -ffree-line-length-none -fdefault-real-8 -C")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-none -fdefault-real-8 -C")
 
   # debug flags
   if(CMAKE_BUILD_TYPE MATCHES Debug)
@@ -37,7 +37,7 @@ endmacro(set_ifort)
 
 # Customizations for Intel Fortran Compiler on posix systems
 macro(set_ifort_posix)
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -m64 -fpp -real-size 64")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fpp -real-size 64")
 
   # debug flags
   if(CMAKE_BUILD_TYPE MATCHES Debug)

--- a/glue-codes/openfast/5MW_Baseline/ServoData/DISCON_ITI/CMakeLists.txt
+++ b/glue-codes/openfast/5MW_Baseline/ServoData/DISCON_ITI/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 # Customizations for GNU Fortran compiler
 macro(set_gfortran)
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -m64 -ffree-line-length-none -fdefault-real-8 -C")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-none -fdefault-real-8 -C")
 
   # debug flags
   if(CMAKE_BUILD_TYPE MATCHES Debug)
@@ -37,7 +37,7 @@ endmacro(set_ifort)
 
 # Customizations for Intel Fortran Compiler on posix systems
 macro(set_ifort_posix)
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -m64 -fpp -real-size 64")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fpp -real-size 64")
 
   # debug flags
   if(CMAKE_BUILD_TYPE MATCHES Debug)

--- a/glue-codes/openfast/5MW_Baseline/ServoData/DISCON_OC3/CMakeLists.txt
+++ b/glue-codes/openfast/5MW_Baseline/ServoData/DISCON_OC3/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 # Customizations for GNU Fortran compiler
 macro(set_gfortran)
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -m64 -ffree-line-length-none -fdefault-real-8 -C")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-none -fdefault-real-8 -C")
 
   # debug flags
   if(CMAKE_BUILD_TYPE MATCHES Debug)
@@ -37,7 +37,7 @@ endmacro(set_ifort)
 
 # Customizations for Intel Fortran Compiler on posix systems
 macro(set_ifort_posix)
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -m64 -fpp -real-size 64")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fpp -real-size 64")
 
   # debug flags
   if(CMAKE_BUILD_TYPE MATCHES Debug)


### PR DESCRIPTION
The -m64 flag, which is added to CMAKE_Fortran_FLAGS in the /reg_tests/r-test/glue-codes/fast-farm/5MW_Baseline/ServoData/DISCON* CMakeLists.txt files, prevents the executables from building on the arm64 (aarch64) platform (specifically M1 Mac processor, likely others). This commit removes this flag from the affected files.