### PR TITLE
Corrections to NumCoords, from 67 --> 66

### DIFF
--- a/glue-codes/openfast/UAE_VI/Airfoils/S809_coordinates.txt
+++ b/glue-codes/openfast/UAE_VI/Airfoils/S809_coordinates.txt
@@ -1,4 +1,4 @@
-        67   NumCoords         ! The number of coordinates in the airfoil shape file (including an extra coordinate for airfoil reference).  Set to zero if coordinates not included.
+        66   NumCoords         ! The number of coordinates in the airfoil shape file (including an extra coordinate for airfoil reference).  Set to zero if coordinates not included.
 ! ......... x-y coordinates are next if NumCoords > 0 .............
 ! x-y coordinate of airfoil reference
 !  x/c        y/c


### PR DESCRIPTION
The NumCoords is set as 67, but there are just 66 coordinate entries:

![image](https://github.com/user-attachments/assets/fd28a7bb-59e5-4ccf-959f-4fbc73247592)

Caught when reading and writing files with openfast_io