### PR TITLE
GuyanLoadCorrection in SubDyn

### DIFF
--- a/glue-codes/openfast/5MW_OC3Mnpl_DLL_WTurb_WavesIrr/NRELOffshrBsline5MW_OC3Monopile_SubDyn.dat
+++ b/glue-codes/openfast/5MW_OC3Mnpl_DLL_WTurb_WavesIrr/NRELOffshrBsline5MW_OC3Monopile_SubDyn.dat
@@ -5,7 +5,7 @@ False            Echo        - Echo input data to "<rootname>.SD.ech" (flag)
 "DEFAULT"        SDdeltaT    - Local Integration Step. If "default", the glue-code integration step will be used.
              3   IntMethod   - Integration Method [1/2/3/4 = RK4/AB4/ABM4/AM2].
 True             SttcSolve   - Solve dynamics about static equilibrium point
-False            GuyanLoadCorrection - Include extra moment from lever arm at interface and rotate FEM for floating.
+True             GuyanLoadCorrection - Include extra moment from lever arm at interface and rotate FEM for floating.
 -------------------- FEA and CRAIG-BAMPTON PARAMETERS ---------------------------------
              3   FEMMod      - FEM switch: element model in the FEM. [1= Euler-Bernoulli(E-B);  2=Tapered E-B (unavailable);  3= 2-node Timoshenko;  4= 2-node tapered Timoshenko (unavailable)]
              3   NDiv        - Number of sub-elements per member

--- a/glue-codes/openfast/5MW_OC3Mnpl_Linear/NRELOffshrBsline5MW_OC3Monopile_SubDyn.dat
+++ b/glue-codes/openfast/5MW_OC3Mnpl_Linear/NRELOffshrBsline5MW_OC3Monopile_SubDyn.dat
@@ -5,7 +5,7 @@ False            Echo        - Echo input data to "<rootname>.SD.ech" (flag)
 "DEFAULT"        SDdeltaT    - Local Integration Step. If "default", the glue-code integration step will be used.
              3   IntMethod   - Integration Method [1/2/3/4 = RK4/AB4/ABM4/AM2].
 True             SttcSolve   - Solve dynamics about static equilibrium point
-False            GuyanLoadCorrection - Include extra moment from lever arm at interface and rotate FEM for floating.
+True             GuyanLoadCorrection - Include extra moment from lever arm at interface and rotate FEM for floating.
 -------------------- FEA and CRAIG-BAMPTON PARAMETERS ---------------------------------
              3   FEMMod      - FEM switch: element model in the FEM. [1= Euler-Bernoulli(E-B);  2=Tapered E-B (unavailable);  3= 2-node Timoshenko;  4= 2-node tapered Timoshenko (unavailable)]
              3   NDiv        - Number of sub-elements per member

--- a/glue-codes/openfast/5MW_OC3Trpd_DLL_WSt_WavesReg/NRELOffshrBsline5MW_OC3Tripod_SubDyn.dat
+++ b/glue-codes/openfast/5MW_OC3Trpd_DLL_WSt_WavesReg/NRELOffshrBsline5MW_OC3Tripod_SubDyn.dat
@@ -5,7 +5,7 @@ False            Echo        - Echo input data to "<rootname>.SD.ech" (flag)
 "DEFAULT"        SDdeltaT    - Local Integration Step. If "default", the glue-code integration step will be used.
              3   IntMethod   - Integration Method [1/2/3/4 = RK4/AB4/ABM4/AM2].
 True             SttcSolve   - Solve dynamics about static equilibrium point
-False            GuyanLoadCorrection - Include extra moment from lever arm at interface and rotate FEM for floating.
+True             GuyanLoadCorrection - Include extra moment from lever arm at interface and rotate FEM for floating.
 -------------------- FEA and CRAIG-BAMPTON PARAMETERS ---------------------------------
              3   FEMMod      - FEM switch: element model in the FEM. [1= Euler-Bernoulli(E-B);  2=Tapered E-B (unavailable);  3= 2-node Timoshenko;  4= 2-node tapered Timoshenko (unavailable)]
              1   NDiv        - Number of sub-elements per member

--- a/glue-codes/openfast/5MW_OC4Jckt_DLL_WTurb_WavesIrr_MGrowth/NRELOffshrBsline5MW_OC4Jacket_SubDyn.dat
+++ b/glue-codes/openfast/5MW_OC4Jckt_DLL_WTurb_WavesIrr_MGrowth/NRELOffshrBsline5MW_OC4Jacket_SubDyn.dat
@@ -5,7 +5,7 @@ False            Echo        - Echo input data to "<rootname>.SD.ech" (flag)
 "DEFAULT"        SDdeltaT    - Local Integration Step. If "default", the glue-code integration step will be used.
              3   IntMethod   - Integration Method [1/2/3/4 = RK4/AB4/ABM4/AM2].
 True             SttcSolve   - Solve dynamics about static equilibrium point
-False            GuyanLoadCorrection - Include extra moment from lever arm at interface and rotate FEM for floating.
+True             GuyanLoadCorrection - Include extra moment from lever arm at interface and rotate FEM for floating.
 -------------------- FEA and CRAIG-BAMPTON PARAMETERS ---------------------------------
              3   FEMMod      - FEM switch: element model in the FEM. [1= Euler-Bernoulli(E-B);  2=Tapered E-B (unavailable);  3= 2-node Timoshenko;  4= 2-node tapered Timoshenko (unavailable)]
              2   NDiv        - Number of sub-elements per member


### PR DESCRIPTION
The GuyanLoadCorrection in SubDyn should be always defined as True for fixed-bottom and floating wind turbines.

In the r-test repo, all the models that include SubDyn are fixed-bottom. For these numerical models, the GuyanLoadCorrection will account for the lever arm distance at the interface joint providing more accurate results.

I guess, the automatic testing check may fail because the results are now different. But the results with GuyanLoadCorrection = True are more accurate.

As far as I know, this GuyanLoadCorrection flag may be removed in the future and left as True internally.