### PR TITLE
Refactor r-tests for C-bindings interfaces

### DIFF
--- a/modules/aerodyn/py_ad_5MW_OC4Semi_WSt_WavesWN/py_ad_driver.py
+++ b/modules/aerodyn/py_ad_5MW_OC4Semi_WSt_WavesWN/py_ad_driver.py
@@ -225,7 +225,7 @@ class AeroDynDriver:
         Raises:
             SystemExit: If library initialization fails.
         """
-        library_path = get_library_path()
+        library_path = get_library_path(module_name="aerodyn")
         try:
             adilib = adi.AeroDynInflowLib(library_path)
         except Exception as e:

--- a/modules/aerodyn/py_ad_5MW_OC4Semi_WSt_WavesWN/py_ad_driver.py
+++ b/modules/aerodyn/py_ad_5MW_OC4Semi_WSt_WavesWN/py_ad_driver.py
@@ -98,7 +98,7 @@ class AeroDynConfig:
     debug_outputs: int = 1         # For checking the interface, set this to 1
 
     #--------------------------------------
-    # File paths
+    # File names
     #--------------------------------------
     vtk_dir: str = "vtkRef"
     # Primary input files: This is identical to what AeroDyn would read from disk
@@ -178,7 +178,7 @@ class AeroDynDriver:
         them as class attributes for later use in the simulation.
         """
         # Initialize hub and nacelle positions
-        read_vtk_ref = lambda root_name: visread_positions_ref(
+        read_vtk_ref = lambda root_name: read_reference_positions_from_vtk(
             os.path.sep.join([self.config.vtk_dir, root_name + "_Reference.vtp"])
         )
         self.init_hub_pos, self.init_hub_orient, num_pts = read_vtk_ref(

--- a/modules/aerodyn/py_ad_5MW_OC4Semi_WSt_WavesWN/py_ad_driver.py
+++ b/modules/aerodyn/py_ad_5MW_OC4Semi_WSt_WavesWN/py_ad_driver.py
@@ -235,32 +235,32 @@ class AeroDynDriver:
         #--------------------------------------
         # Configure library
         #--------------------------------------
-        adilib.InterpOrder   = self.lib_config.interpolation_order
+        adilib.interpolation_order   = self.lib_config.interpolation_order
 
         # Time settings
         adilib.dt            = self.lib_config.time_interval
-        adilib.numTimeSteps  = self.config.time_steps_to_run
+        adilib.num_time_steps  = self.config.time_steps_to_run
 
         # Physical parameters
         adilib.gravity       = self.lib_config.gravity
-        adilib.defFldDens    = self.lib_config.density
-        adilib.defKinVisc    = self.lib_config.kinematic_viscosity
-        adilib.defSpdSound   = self.lib_config.speed_of_sound
-        adilib.defPatm       = self.lib_config.atmospheric_pressure
-        adilib.defPvap       = self.lib_config.vapor_pressure
-        adilib.WtrDpth       = self.lib_config.water_depth
-        adilib.MSL2SWL       = self.lib_config.mean_sea_level_offset
-        adilib.numTurbines   = self.config.num_turbines
+        adilib.fluid_density  = self.lib_config.density
+        adilib.kinematic_viscosity  = self.lib_config.kinematic_viscosity
+        adilib.sound_speed      = self.lib_config.speed_of_sound
+        adilib.atm_pressure          = self.lib_config.atmospheric_pressure
+        adilib.vapor_pressure          = self.lib_config.vapor_pressure
+        adilib.water_depth       = self.lib_config.water_depth
+        adilib.msl_to_swl       = self.lib_config.mean_sea_level_offset
+        adilib.num_turbines   = self.config.num_turbines
 
         # Visualization settings
-        adilib.storeHHvel    = self.lib_config.store_horizontal_hub_velocity
-        adilib.WrVTK         = self.lib_config.write_vtk
-        adilib.WrVTK_Type    = self.lib_config.write_vtk_type
-        adilib.WrVTK_DT      = self.lib_config.write_vtk_dt
-        adilib.transposeDCM  = self.lib_config.transpose_dcm
+        adilib.store_hub_height_velocity    = self.lib_config.store_horizontal_hub_velocity
+        adilib.write_vtk         = self.lib_config.write_vtk
+        adilib.vtk_type    = self.lib_config.write_vtk_type
+        adilib.vtk_dt      = self.lib_config.write_vtk_dt
+        adilib.transpose_dcm  = self.lib_config.transpose_dcm
 
         # Debugging of internals of ADI library
-        adilib.debuglevel    = self.lib_config.debug_level
+        adilib.debug_level    = self.lib_config.debug_level
 
         return adilib
 
@@ -272,13 +272,13 @@ class AeroDynDriver:
         debug_output_file = None
         if self.config.debug_outputs:
             debug_output_file = adi.DriverDbg(
-                self.config.debug_output_file, self.adilib.numMeshPts
+                self.config.debug_output_file, self.adilib.num_mesh_pts
             )
 
         try:
             # Time stepping loop with corrections
-            print(f"Time steps: {self.adilib.numTimeSteps}")
-            for i in range(0, self.adilib.numTimeSteps + 1):
+            print(f"Time steps: {self.adilib.num_time_steps}")
+            for i in range(0, self.adilib.num_time_steps + 1):
                 current_time = i * self.adilib.dt
                 print(f"Time step: {i} at {current_time}")
 
@@ -304,11 +304,13 @@ class AeroDynDriver:
                 sys.exit(1)
 
         # Save results to output file
+        print(f"Writing output to {self.config.output_file}")
         out_file = adi.WriteOutChans(
             self.config.output_file, self.output_channel_names, self.output_channel_units
         )
         out_file.write(self.all_output_channel_values)
         out_file.end()
+        print(f"Output written to {self.config.output_file}")
         print("Simulation completed successfully")
 
     def _initialize_simulation(self) -> None:
@@ -318,19 +320,19 @@ class AeroDynDriver:
             SystemExit: If pre-initialization or initialization of AeroDyn fails
         """
         # Set initial positions and orientations
-        self.adilib.initHubPos = self.init_hub_pos[0,:]
-        self.adilib.initHubOrient = self.init_hub_orient[0,:]
-        self.adilib.initNacellePos = self.init_nacelle_pos[0,:]
-        self.adilib.initNacelleOrient = self.init_nacelle_orient[0,:]
-        self.adilib.numBlades = self.config.num_blades
-        self.adilib.initRootPos = self.init_root_pos
-        self.adilib.initRootOrient = self.init_root_orient
+        self.adilib.init_hub_pos = self.init_hub_pos[0,:]
+        self.adilib.init_hub_orient = self.init_hub_orient[0,:]
+        self.adilib.init_nacelle_pos = self.init_nacelle_pos[0,:]
+        self.adilib.init_nacelle_orient = self.init_nacelle_orient[0,:]
+        self.adilib.num_blades = self.config.num_blades
+        self.adilib.init_root_pos = self.init_root_pos
+        self.adilib.init_root_orient = self.init_root_orient
 
         # Set mesh data
-        self.adilib.numMeshPts = np.size(self.init_mesh_pos, 0)
-        self.adilib.initMeshPos = self.init_mesh_pos
-        self.adilib.initMeshOrient = self.init_mesh_orient
-        self.adilib.meshPtToBladeNum = self.init_mesh_pt_to_blade_num
+        self.adilib.num_mesh_pts = np.size(self.init_mesh_pos, 0)
+        self.adilib.init_mesh_pos = self.init_mesh_pos
+        self.adilib.init_mesh_orient = self.init_mesh_orient
+        self.adilib.mesh_pt_to_blade_num = self.init_mesh_pt_to_blade_num
 
         #--------------------------------------
         # Initialize the library
@@ -358,9 +360,9 @@ class AeroDynDriver:
         self.output_channel_units = self.adilib.output_channel_units
 
         # Initialize output arrays
-        self.output_channel_values = np.zeros(self.adilib.numChannels)
+        self.output_channel_values = np.zeros(self.adilib.num_channels)
         self.all_output_channel_values = np.zeros((
-            self.config.time_steps_to_run + 1, self.adilib.numChannels + 1
+            self.config.time_steps_to_run + 1, self.adilib.num_channels + 1
         ))
         self.disk_avg_vel = np.zeros(3)  # [Vx Vy Vz]
 
@@ -395,19 +397,20 @@ class AeroDynDriver:
         """
         # Get motion data for current timestep from vtk
         hub_pos, hub_orient, hub_vel, hub_acc = self._set_motion_hub(i_timestep)
+        hub_motion = adi.MotionData(hub_pos, hub_orient, hub_vel, hub_acc)
         nac_pos, nac_orient, nac_vel, nac_acc = self._set_motion_nacelle(i_timestep)
+        nac_motion = adi.MotionData(nac_pos, nac_orient, nac_vel, nac_acc)
         root_pos, root_orient, root_vel, root_acc = self._set_motion_root(i_timestep)
+        root_motion = adi.MotionData(root_pos, root_orient, root_vel, root_acc)
         mesh_pos, mesh_orient, mesh_vel, mesh_acc, mesh_forces_moments = self._set_motion_blade_mesh(i_timestep)
+        mesh_motion = adi.MotionData(mesh_pos, mesh_orient, mesh_vel, mesh_acc)
 
         # Set rotor motion for each turbine
         for i_turbine in range(self.config.num_turbines):
             try:
                 self.adilib.adi_setrotormotion(
                     i_turbine + 1,  # 1-based indexing for turbines
-                    hub_pos, hub_orient, hub_vel, hub_acc,
-                    nac_pos, nac_orient, nac_vel, nac_acc,
-                    root_pos, root_orient, root_vel, root_acc,
-                    mesh_pos, mesh_orient, mesh_vel, mesh_acc
+                    hub_motion, nac_motion, root_motion, mesh_motion
                 )
             except Exception as e:
                 print(f"Failed to set rotor motion at T={current_time}: {e}")
@@ -431,10 +434,7 @@ class AeroDynDriver:
                 try:
                     self.adilib.adi_setrotormotion(
                         i_turbine + 1,  # 1-based indexing for turbines
-                        hub_pos, hub_orient, hub_vel, hub_acc,
-                        nac_pos, nac_orient, nac_vel, nac_acc,
-                        root_pos, root_orient, root_vel, root_acc,
-                        mesh_pos, mesh_orient, mesh_vel, mesh_acc
+                        hub_motion, nac_motion, root_motion, mesh_motion
                     )
                 except Exception as e:
                     print(f"Failed to set rotor motion at T={current_time}: {e}")

--- a/modules/aerodyn/py_ad_5MW_OC4Semi_WSt_WavesWN/py_ad_driver.py
+++ b/modules/aerodyn/py_ad_5MW_OC4Semi_WSt_WavesWN/py_ad_driver.py
@@ -130,7 +130,7 @@ class LibraryConfig:
     gravity: float = 9.80665                    # Gravitational acceleration (m/s^2)
     density: float = 1.225                      # Air density (kg/m^3)
     kinematic_viscosity: float = 1.464E-05      # Kinematic viscosity of working fluid (m^2/s)
-    speed_of_sound: float = 335.                # Speed of sound in working fluid (m/s)
+    sound_speed: float = 335.                   # Speed of sound in working fluid (m/s)
     atmospheric_pressure: float = 103500.       # Atmospheric pressure (Pa) [used only for an MHK turbine cavitation check]
     vapor_pressure: float = 1700.               # Vapor pressure of working fluid (Pa) [used only for an MHK turbine cavitation check]
     water_depth: float = 0.                     # Water depth (m)
@@ -235,32 +235,32 @@ class AeroDynDriver:
         #--------------------------------------
         # Configure library
         #--------------------------------------
-        adilib.interpolation_order   = self.lib_config.interpolation_order
+        adilib.interpolation_order      = self.lib_config.interpolation_order
 
         # Time settings
-        adilib.dt            = self.lib_config.time_interval
-        adilib.num_time_steps  = self.config.time_steps_to_run
+        adilib.dt                       = self.lib_config.time_interval
+        adilib.num_time_steps           = self.config.time_steps_to_run
 
         # Physical parameters
-        adilib.gravity       = self.lib_config.gravity
-        adilib.fluid_density  = self.lib_config.density
-        adilib.kinematic_viscosity  = self.lib_config.kinematic_viscosity
-        adilib.sound_speed      = self.lib_config.speed_of_sound
-        adilib.atm_pressure          = self.lib_config.atmospheric_pressure
-        adilib.vapor_pressure          = self.lib_config.vapor_pressure
-        adilib.water_depth       = self.lib_config.water_depth
-        adilib.msl_to_swl       = self.lib_config.mean_sea_level_offset
-        adilib.num_turbines   = self.config.num_turbines
+        adilib.gravity                  = self.lib_config.gravity
+        adilib.fluid_density            = self.lib_config.density
+        adilib.kinematic_viscosity      = self.lib_config.kinematic_viscosity
+        adilib.sound_speed              = self.lib_config.sound_speed
+        adilib.atmospheric_pressure     = self.lib_config.atmospheric_pressure
+        adilib.vapor_pressure           = self.lib_config.vapor_pressure
+        adilib.water_depth              = self.lib_config.water_depth
+        adilib.mean_sea_level_offset    = self.lib_config.mean_sea_level_offset
+        adilib.num_turbines             = self.config.num_turbines
 
         # Visualization settings
-        adilib.store_hub_height_velocity    = self.lib_config.store_horizontal_hub_velocity
-        adilib.write_vtk         = self.lib_config.write_vtk
-        adilib.vtk_type    = self.lib_config.write_vtk_type
-        adilib.vtk_dt      = self.lib_config.write_vtk_dt
-        adilib.transpose_dcm  = self.lib_config.transpose_dcm
+        adilib.store_hub_height_velocity = self.lib_config.store_horizontal_hub_velocity
+        adilib.write_vtk                 = self.lib_config.write_vtk
+        adilib.vtk_type                  = self.lib_config.write_vtk_type
+        adilib.vtk_dt                    = self.lib_config.write_vtk_dt
+        adilib.transpose_dcm             = self.lib_config.transpose_dcm
 
         # Debugging of internals of ADI library
-        adilib.debug_level    = self.lib_config.debug_level
+        adilib.debug_level              = self.lib_config.debug_level
 
         return adilib
 

--- a/modules/aerodyn/py_ad_B1n2_OLAF/py_ad_driver.py
+++ b/modules/aerodyn/py_ad_B1n2_OLAF/py_ad_driver.py
@@ -1,8 +1,9 @@
-#*******************************************************************************
+#-------------------------------------------------------------------------------
 # LICENSING
-# Copyright (C) 2021 National Renewable Energy Lab
+#-------------------------------------------------------------------------------
+# Copyright (C) 2021-present by National Renewable Energy Lab (NREL)
 #
-# This file is part of AeroDyn. 
+# This file is part of AeroDyn
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,568 +16,477 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+#-------------------------------------------------------------------------------
+# Overview of AeroDyn x InflowWind python driver
+#-------------------------------------------------------------------------------
+# This script serves as a Python driver for the AeroDyn library with InflowWind
+# integration. It demonstrates how to interact with the main subroutines of
+# AeroDyn.
 #
-#*******************************************************************************
+# NOTE: This script serves as a template and can be customized to meet
+# individual requirements.
 #
-# This is an exampe of Python driver code for AeroDyn with InflowWind
+# Workflow for using the AeroDyn x InflowWind Python library:
+#   1. Initialize the Python Wrapper:
+#      - Set necessary library parameters (e.g., number of turbines, simulation
+#        time)
+#      - Load input file data (from file/script)
 #
-# Usage: This program gives an example for how the user calls the main
-#        subroutines of AeroDyn, and thus is specific to the user
+#   2. Initialize the AeroDyn Fortran Library (C-bindings interface):
+#      - ADI_PreInit: Specify the number of turbines
+#      - ADI_SetupTurb: Initialize each rotor and iterate over turbines
+#      - ADI_Init: Initialize the simulation environment by calling ADI
 #
-# Basic alogrithm for using AeroDyn InflowWind python library
-#   1.  initialize python wrapper library
-#           set necessary library values
-#           set input file string arrays (from file or script)
-#   2.  initialize AeroDyn Fortran library
-#           - ADI_PreInit       -- set number of turbines
-#           - ADI_SetupTurb     -- initialize one rotor (iterate over turbines)
-#           - ADI_Init          -- actually call ADI to initialize the simulation
-#   3.  timestep iteration
-#           - ADI_SetMotion     -- set motions of single turbine (iterate over turbines)
-#           - ADI_UpdateStates  -- update to next timestep
-#           - ADI_CalcOutput    -- get outputs
-#           - ADI_GetRotorLoads -- get loads per rotor (iterate over turbines)
-#   4. End
-#         call adi_end to close the AeroDyn library and free memory
-#         handle any resulting errors
+#   3. Perform Timestep Iterations:
+#      - ADI_SetRotorMotion: Define the motion parameters for each turbine and iterate
+#        over turbines
+#      - ADI_UpdateStates: Advance the simulation to the next timestep
+#      - ADI_CalcOutput: Retrieve simulation outputs
+#      - ADI_GetRotorLoads: Obtain load data for each rotor and iterate over
+#        turbines
 #
-#
-import numpy as np
+#   4. Finalize the Simulation:
+#      - Call adi_end to properly close the AeroDyn library and release resources
+#      - Handle any errors that may have occurred during the process
+
+#-------------------------------------------------------------------------------
+# Imports
+#-------------------------------------------------------------------------------
 import os
 import sys
-from visread import *
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
 
-# path to find the aerodyn_inflow_library.py from the local directory
-os.chdir(sys.path[0])
-adiLibPath=os.path.sep.join(["..", "..", "..", "..", "..", "modules", "aerodyn", "python-lib"])
-sys.path.insert(0, adiLibPath)
-print(f"Importing 'aerodyn_inflow_library' from {adiLibPath}")
-import aerodyn_inflow_library as adi # this file handles the conversion from python to c-bound types and should not be changed by the user
+import numpy as np
 
-###############################################################################
-# Locations to build directory relative to r-test directory.  This is specific
-# to the regession testing with openfast and will need to be updated when
-# coupled to other codes or use cases
-
-basename = "libaerodyn_inflow_c_binding"
-builddir=os.path.sep.join(["..", "..", "..", "..", "..", "build"])
-if sys.platform == "linux" or sys.platform == "linux2":
-    library_path = os.path.sep.join([builddir, "modules", "aerodyn", basename + ".so"])
-elif sys.platform == "darwin":
-    library_path = os.path.sep.join([builddir, "modules", "aerodyn", basename + ".dylib"])
-elif sys.platform == "win32":
-    # Windows may have this library installed in one of two locations depending
-    # on which build system was used (CMake or VS).
-    library_path = os.path.sep.join([builddir, "modules", "aerodyn", basename + ".dll"])   # cmake install location
-    if not os.path.isfile(library_path) and not sys.maxsize > 2**32:        # Try VS build location otherwise
-        library_path = os.path.sep.join([builddir, "bin", "AeroDyn_Inflow_c_binding_Win32.dll"]) # VS build install location
-        if not os.path.isfile(library_path):
-            print(f"Python is 32 bit and cannot find 32 bit InflowWind DLL expected at: {library_path}")
-            exit(1)
-    if not os.path.isfile(library_path) and sys.maxsize > 2**32:        # Try VS build location otherwise
-        library_path = os.path.sep.join([builddir, "bin", "AeroDyn_Inflow_c_binding_x64.dll"]) # VS build install location
-        if not os.path.isfile(library_path):
-            print(f"Python is 64 bit and cannot find 64 bit InflowWind DLL expected at: {library_path}")
-            exit(1)
-
-
-
-###############################################################################
-# For testing, a set of input files is read in.  Everything in these input
-# files could in principle be hard coded into this script.  These are separated
-# out for convenience in testing.
-
-#   Primary input
-#       This is identical to what AeroDyn would read from disk if we were
-#       not passing it.  When coupled to other codes, this may be passed
-#       directly from memory (i.e. during optimization with WEIS), or read as a
-#       template and edited in memory for each iteration loop.
-primary_ad_file="AeroDyn.dat"
-primary_ifw_file="ifw_primary.dat"
-
-#   Debug output file
-#       When coupled into another code, an array of position/orientation,
-#       velocities, and accelerations are passed in, and an array of
-#       Forces+Moments is returned.  For debugging, it may be useful to dump all
-#       off this to file.
-DbgOuts=0                       #   For checking the interface, set this to 1
-debugout_file="DbgOutputs.out"
-
-#   Output file
-#       When coupled to another code, the channels requested in the outlist
-#       section of the output file are passed back for writing to file.  Here
-#       we will write the aggregated output channels to a file at the end of
-#       the simulation.
-output_file="py_ad_driver.out"
-
-#   For checking if our library is correctly handling correction steps, set
-#   this to > 0
-NumCorrections=0
-
-
-#===============================================================================
-#   Mesh inputs from vtk
-vtkDir="vtkRef"
-numBlades=1
-vtkFieldLen=9
-TimeStepsToRun=59
-hubMeshRootName="AD_HubMotion"
-nacMeshRootName="AD_Nacelle"
-bldRootMeshRootName="AD_BladeRootMotion"
-bldMeshRootName="AD_BladeMotion"   # for struct mesh not aligned with AeroDyn mesh
-
-
-
-#   Input Files
-#===============================================================================
-#   Main AeroDyn input file
-#       This file is read from disk to an array of strings with the line
-#       endings stripped off.  This array will have the same number of elements
-#       as there are lines in the file.
-adiAD_input_string_array = []     # instantiate empty array
-fh = open(primary_ad_file, "r")
-for line in fh:
-  # strip line ending and ending white space and add to array of strings
-  adiAD_input_string_array.append(line.rstrip())
-fh.close()
-
-adiIfW_input_string_array = []     # instantiate empty array
-fh = open(primary_ifw_file, "r")
-for line in fh:
-  # strip line ending and ending white space and add to array of strings
-  adiIfW_input_string_array.append(line.rstrip())
-fh.close()
-
-
-#===============================================================================
-#   Number of turbines
-numTurbines = 1
-
-#===============================================================================
-#   Initial hub and root locations from vtk files
-#       can add checks here that numpts==1
-initHubPos,     initHubOrient,     numpts = visread_positions_ref(os.path.sep.join([vtkDir, hubMeshRootName+"_Reference.vtp"]))
-initNacellePos, initNacelleOrient, numpts = visread_positions_ref(os.path.sep.join([vtkDir, nacMeshRootName+"_Reference.vtp"]))
-
-initRootPos     = np.zeros((numBlades,3),dtype="float32")
-initRootOrient  = np.zeros((numBlades,9),dtype="float64")
-for i in range(numBlades):
-    #   can add checks here that numpts==1
-    initRootPos[i,:], initRootOrient[i,:], numpts = visread_positions_ref(os.path.sep.join([vtkDir, bldRootMeshRootName+str(i+1)+"_Reference.vtp"]))
-
-#   Initial blade mesh positions
-numBladeNode = np.zeros( (numBlades), dtype=int )
-initMeshPos_ar    = np.empty( (0,3), dtype="float32" )
-initMeshOrient_ar = np.empty( (0,9), dtype="float64" )
-initMeshPtToBladeNum_ar = np.empty( (0), dtype=int )
-for i in range(numBlades):
-    #   can add checks here that numpts==1
-    tmpPos, tmpOrient, numpts = visread_positions_ref(os.path.sep.join([vtkDir, bldMeshRootName+str(i+1)+"_Reference.vtp"]))
-    initMeshPos_ar    = np.concatenate((initMeshPos_ar,   tmpPos   ))
-    initMeshOrient_ar = np.concatenate((initMeshOrient_ar,tmpOrient))
-    numBladeNode[i] = numpts
-    # store which blade number this is that these points belong to
-    tmpPtToBladeNum = np.zeros( numpts, dtype=int )
-    tmpPtToBladeNum.fill(i+1)
-    initMeshPtToBladeNum_ar = np.concatenate((initMeshPtToBladeNum_ar,tmpPtToBladeNum))
-del tmpPos
-del tmpOrient
-
-#===============================================================================
-#   Helper functions
-#===============================================================================
-def SetMotionHub(N_Step):
-    timeField=str(N_Step).zfill(vtkFieldLen)
-    HubPos, HubOrient, numpts = visread_positions(os.path.sep.join([vtkDir, hubMeshRootName+'.'+timeField+".vtp"]))
-    HubVel, HubAcc            = visread_velacc(   os.path.sep.join([vtkDir, hubMeshRootName+'.'+timeField+".vtp"]),numpts)
-    return (HubPos, HubOrient, HubVel, HubAcc)
-
-def SetMotionNac(N_Step):
-    timeField=str(N_Step).zfill(vtkFieldLen)
-    NacPos, NacOrient, numpts = visread_positions(os.path.sep.join([vtkDir, nacMeshRootName+'.'+timeField+".vtp"]))
-    NacVel, NacAcc            = visread_velacc(   os.path.sep.join([vtkDir, nacMeshRootName+'.'+timeField+".vtp"]),numpts)
-    return (NacPos, NacOrient, NacVel, NacAcc)
-
-def SetMotionRoot(N_Step):
-    timeField=str(N_Step).zfill(vtkFieldLen)
-    RootPos       = np.zeros((numBlades,3),dtype="float32")
-    RootOrient    = np.zeros((numBlades,9),dtype="float64")
-    RootVel       = np.zeros((numBlades,6),dtype="float32")
-    RootAcc       = np.zeros((numBlades,6),dtype="float32")
-    for k in range(numBlades):
-        RootPos[k,:], RootOrient[k,:], numpts = visread_positions(os.path.sep.join([vtkDir, bldRootMeshRootName+str(k+1)+'.'+timeField+".vtp"]))
-        RootVel[k,:], RootAcc[k,:]            = visread_velacc(   os.path.sep.join([vtkDir, bldRootMeshRootName+str(k+1)+'.'+timeField+".vtp"]),numpts)
-    return (RootPos, RootOrient, RootVel, RootAcc)
-
-def SetMotionBlMesh(N_Step):
-    timeField=str(N_Step).zfill(vtkFieldLen)
-    MeshPos_ar    = np.empty( (0,3), dtype="float32" )
-    MeshOrient_ar = np.empty( (0,9), dtype="float64" )
-    MeshVel_ar    = np.empty( (0,6), dtype="float32" )
-    MeshAcc_ar    = np.empty( (0,6), dtype="float32" )
-    MeshFrcMom    = np.zeros((sum(numBladeNode),6))       # [Fx,Fy,Fz,Mx,My,Mz]   -- resultant forces/moments at each node
-    for k in range(numBlades):
-        tmpPos, tmpOrient, numpts = visread_positions(os.path.sep.join([vtkDir, bldMeshRootName+str(k+1)+'.'+timeField+".vtp"]))
-        tmpVel, tmpAcc            = visread_velacc(   os.path.sep.join([vtkDir, bldMeshRootName+str(k+1)+'.'+timeField+".vtp"]),numpts)
-        MeshPos_ar    = np.concatenate((MeshPos_ar,   tmpPos   ))
-        MeshOrient_ar = np.concatenate((MeshOrient_ar,tmpOrient))
-        MeshVel_ar    = np.concatenate((MeshVel_ar,   tmpVel   ))
-        MeshAcc_ar    = np.concatenate((MeshAcc_ar,   tmpAcc   ))
-    del tmpPos
-    del tmpOrient
-    del tmpVel
-    del tmpAcc
-    return (MeshPos_ar, MeshOrient_ar, MeshVel_ar, MeshAcc_ar, MeshFrcMom)
-
-#===============================================================================
-#   AeroDyn python interface initialization 
-#===============================================================================
-
-#   Instantiate the hdlib python object
-#       wrap this in error handling in case the library_path is incorrect
-try:
-    adilib = adi.AeroDynInflowLib(library_path)
-except Exception as e:
-    print("{}".format(e))
-    print(f"Cannot load library at {library_path}")
-    exit(1)
-
-# These will be read from the AD driver input file
-#   Time inputs
-#           adlib.dt           -- the timestep aerodyn is called at.
-#           adlib.numTimeSteps -- total number of timesteps, only used to
-#                                  construct arrays to hold the output channel
-#                                  info
-adilib.InterpOrder   = 2          # order of the interpolation
-adilib.dt            = 0.1        # time interval that it's being called at
-final_time           = 5.9        # final time
-adilib.gravity       =   9.80665  # Gravitational acceleration (m/s^2)
-adilib.defFldDens    =     1.225  # Air density (kg/m^3)
-adilib.defKinVisc    = 1.464E-05  # Kinematic viscosity of working fluid (m^2/s)
-adilib.defSpdSound   =     335.0  # Speed of sound in working fluid (m/s)
-adilib.defPatm       =  103500.0  # Atmospheric pressure (Pa) [used only for an MHK turbine cavitation check]
-adilib.defPvap       =    1700.0  # Vapour pressure of working fluid (Pa) [used only for an MHK turbine cavitation check]
-adilib.WtrDpth       =       0.0  # Water depth (m)
-adilib.MSL2SWL       =       0.0  # Offset between still-water level and mean sea level (m) [positive upward]
-adilib.numTurbines   = numTurbines
-
-# Setup some timekeeping -- this may be smaller than what is passed to AeroDyn
-adilib.numTimeSteps = TimeStepsToRun          # only for constructing array of output channels for duration of simulation
-time                = np.arange(0.0,(TimeStepsToRun+1)*adilib.dt,adilib.dt) # total time + increment because python doesnt include endpoint!
-
-# set some flags 
-adilib.storeHHvel   = False
-adilib.WrVTK        = 0         # animation (0: off, 1: init only, 2: all timesteps)
-adilib.WrVTK_Type   = 3         # surface and line meshes
-adilib.transposeDCM = 1         # 0=false, 1=true
-
-#==============================================================================
-# Basic alogrithm for using AeroDyn+InflowWind library
+#--------------------------------------
+# Library paths
+#--------------------------------------
+# Path to find the driver_utilities.py module from the local directory
 #
-# NOTE: the error handling here is handled locally since this is the only
-#       driver code.  If AeroDyn+InflowWind is incorporated into another code,
-#       the error handling will need to be passed to the main code.  That way
-#       the main code can close other modules as necessary (otherwise you will
-#       end up with memory leaks and a bunch of garbage in the other library
-#       instances).
+# NOTE: This file contains helper functions to assist with the driver codes
+# across different modules
+modules_path = Path(__file__).parent.joinpath(*[".."]*5, "reg_tests", "r-test", "modules")
+print(f"Importing 'driver_utilities' from {modules_path}")
+sys.path.insert(0, str(modules_path))
+from driver_utilities import *
 
-isHAWT = 0      # 1: HAWT, 0: VAWT or cross-flow
-
-# Set hub and blade root positions/orientations
-adilib.initHubPos           = initHubPos[0,:]
-adilib.initHubOrient        = initHubOrient[0,:]
-adilib.initNacellePos       = initNacellePos[0,:]
-adilib.initNacelleOrient    = initNacelleOrient[0,:]
-adilib.numBlades            = numBlades
-#adilib.numBladeNode         = numBladeNode     # May be necessary to pass info on nodes on each blade to AeroDyn for mesh mapping.
-adilib.initRootPos          = initRootPos
-adilib.initRootOrient       = initRootOrient
-
-
-# Set number of mesh nodes and initial position
-#       position    is an N x 3 array [x,y,z]
-#       orientation is a  N x 9 array [r11,r12,r13,r21,r22,r23,r31,r32,r33]
-adilib.numMeshPts = np.size(initMeshPos_ar,0)
-adilib.initMeshPos    = initMeshPos_ar
-adilib.initMeshOrient = initMeshOrient_ar
-adilib.meshPtToBladeNum = initMeshPtToBladeNum_ar
-
-# ADI_PreInit: call before anything else
-try:
-    adilib.adi_preinit()
-except Exception as e:
-    print("{}".format(e))   # Exceptions handled in adi_library.py
-    #FIXME: temporary statement here
-    print("Exit after failed call to adi_preinit")
-    exit(1)
-
-# ADI_SetupRotor
-try:
-    #FIXME: hard code to one turbine for now
-    iturb=1
-    turbRefPos=[0,0,0]
-    adilib.adi_setuprotor(iturb,isHAWT,turbRefPos)
-except Exception as e:
-    print("{}".format(e))   # Exceptions handled in adi_library.py
-    #FIXME: temporary statement here
-    print("Exit after failed call to adi_setuprotor")
-    exit(1)
-
-# ADI_Init: Only need to call adi_init once
-try:
-    adilib.adi_init(adiAD_input_string_array,adiIfW_input_string_array)
-except Exception as e:
-    print("{}".format(e))   # Exceptions handled in adi_library.py
-    #FIXME: temporary statement here
-    print("Exit after failed call to adi_init")
-    exit(1)
-
-
-#  To get the names and units of the output channels
-output_channel_names = adilib.output_channel_names
-output_channel_units = adilib.output_channel_units
-
-
-#-------------------
-#   Time steppping
-#-------------------
-
-#  Set the array holding the ouput channel values to zeros initially.  Output
-#  channel values returned from each CalcOutput call in this array.  We will
-#  aggregate them together in the time stepping loop to get the entire time
-#  series.  Time channel is not included, so we must add that.
-outputChannelValues = np.zeros(adilib.numChannels)
-allOutputChannelValues = np.zeros( (adilib.numTimeSteps+1,adilib.numChannels+1) )
-
-#   Open outputfile for regession testing purposes.
-if DbgOuts == 1:
-    dbg_outfile = adi.DriverDbg(debugout_file,adilib.numMeshPts)
-
-#--------------------------------
-# Calculate outputs for t_initial
-i=0
-#   read position/motion from vtk
-HubPos,  HubOrient,  HubVel,  HubAcc  = SetMotionHub(i)
-NacPos,  NacOrient,  NacVel,  NacAcc  = SetMotionNac(i)
-RootPos, RootOrient, RootVel, RootAcc = SetMotionRoot(i)
-MeshPos_ar, MeshOrient_ar, MeshVel_ar, MeshAcc_ar, MeshFrcMom = SetMotionBlMesh(i)
-
-# Set initial motions for rotor 1
-try:
-    adilib.adi_setrotormotion(
-            iturb,
-            HubPos, HubOrient, HubVel, HubAcc,
-            NacPos, NacOrient, NacVel, NacAcc,
-            RootPos, RootOrient, RootVel, RootAcc,
-            MeshPos_ar, MeshOrient_ar, MeshVel_ar, MeshAcc_ar)
-except Exception as e:
-    print("{}".format(e))
-    if DbgOuts == 1:
-        dbg_outfile.end()
-    #FIXME: temporary statement here
-    print("Exit after failed call to adi_calcOutput at T=0")
-    exit(1)
-
-
-print(f"Time step: {i} at {time[i]}")
-try:
-    adilib.adi_calcOutput(time[i],
-            outputChannelValues)
-except Exception as e:
-    print("{}".format(e))
-    if DbgOuts == 1:
-        dbg_outfile.end()
-    #FIXME: temporary statement here
-    print("Exit after failed call to adi_calcOutput at T=0")
-    exit(1)
-
-# get resulting forces
-try:
-    adilib.adi_getrotorloads(
-            iturb,
-            MeshFrcMom)
-except Exception as e:
-    print("{}".format(e))
-    if DbgOuts == 1:
-        dbg_outfile.end()
-    #FIXME: temporary statement here
-    print("Exit after failed call to adi_getrotorloads at T=0")
-    exit(1)
-
- 
-## Write the debug output at t=t_initial
-if DbgOuts == 1:
-    dbg_outfile.write(time[i],MeshPos_ar,MeshVel_ar,MeshAcc_ar,MeshFrcMom)
-# Save the output at t=t_initial
-allOutputChannelValues[i,:] = np.append(time[i],outputChannelValues)
-
-
-#   Timestep iteration
-#       Correction loop:
-#           1.  Set inputs at t+dt using either extrapolated values (or
-#               corrected values if in a correction step) from the structural
-#               solver
-#           2.  Call UpdateStates to propogate states from t -> t+dt
-#           3.  call Ifw_CalcOutput_C to get the resulting forces at t+dt using
-#               the updated state information for t+dt.  These would be passed
-#               back to the structural solver at each step of the correction
-#               loop so that it can be used to tune the states of other modules
-#               (structural solver etc).
-#       End correction loop:
-#           4.  Once correction loop is complete, save the resulting values
+# Path to find the aerodyn_inflow_library.py from the local directory
 #
-#   time[i-1] is at t
-#   time[i]   is at t+dt
-for i in range( 1, len(time)):
+# NOTE: This file handles the conversion from python to C-bound types
+# and should NOT be modified by the user
+os.chdir(Path(__file__).parent)
+adi_lib_path = Path(__file__).parent.joinpath(*[".."]*5, "modules", "aerodyn", "python-lib")
+sys.path.insert(0, str(adi_lib_path))
+print(f"Importing 'aerodyn_inflow_library' from {adi_lib_path}")
+import aerodyn_inflow_library as adi
 
-    # hard code to one turbine for now
-    iturb = 1
+#-------------------------------------------------------------------------------
+# Configuration classes
+#-------------------------------------------------------------------------------
+@dataclass
+class AeroDynConfig:
+    """Configuration settings for AeroDyn simulation."""
+    # Simulation settings
+    num_turbines: int = 1          # Number of turbines
+    is_hawt: int = 0               # 1: HAWT, 0: VAWT or cross-flow
+    num_blades: int = 1            # Number of blades
+    vtk_field_len: int = 9         # Length of the time field in filename
+    time_steps_to_run: int = 59    # Number of time steps to run
+    num_corrections: int = 0       # Number of corrections to perform
+    debug_outputs: int = 0         # For checking the interface, set this to 1
 
-    for correction in range(0, NumCorrections+1):
+    #--------------------------------------
+    # File names
+    #--------------------------------------
+    vtk_dir: str = "vtkRef"
+    primary_ad_file: str = "AeroDyn.dat"
+    primary_ifw_file: str = "ifw_primary.dat"
+    debug_output_file: str = "DbgOutputs.out"
+    output_file: str = "py_ad_driver.out"
 
-        #print(f"Correction step: {correction} for {time[i-1]} --> {time[i]}")
+    # Mesh root names
+    hub_mesh_root: str = "AD_HubMotion"
+    nac_mesh_root: str = "AD_Nacelle"
+    bld_root_mesh_root: str = "AD_BladeRootMotion"
+    bld_mesh_root: str = "AD_BladeMotion"
 
-        # If there are correction steps, the inputs would be updated using outputs
-        # from the other modules.
-        #   read position/motion from vtk
-        HubPos,  HubOrient,  HubVel,  HubAcc  = SetMotionHub(i)
-        NacPos,  NacOrient,  NacVel,  NacAcc  = SetMotionNac(i)
-        RootPos, RootOrient, RootVel, RootAcc = SetMotionRoot(i)
-        MeshPos_ar, MeshOrient_ar, MeshVel_ar, MeshAcc_ar, MeshFrcMom = SetMotionBlMesh(i)
+@dataclass
+class LibraryConfig:
+    """Configuration settings for AeroDyn library."""
+    interpolation_order: int = 2                     # Order of the interpolation
+    dt: float = 0.1                                  # Time interval for ADI calls
+    gravity: float = 9.80665                         # Gravitational acceleration (m/s^2)
+    fluid_density: float = 1.225                     # Air density (kg/m^3)
+    kinematic_viscosity: float = 1.464E-05           # Kinematic viscosity of working fluid (m^2/s)
+    sound_speed: float = 335.0                       # Speed of sound in working fluid (m/s)
+    atmospheric_pressure: float = 103500.0           # Atmospheric pressure (Pa)
+    vapor_pressure: float = 1700.0                   # Vapour pressure of working fluid (Pa)
+    water_depth: float = 0.0                         # Water depth (m)
+    mean_sea_level_offset: float = 0.0               # Offset between still-water level and mean sea level (m)
+    store_hub_height_velocity: bool = False          # Store horizontal hub velocity
+    write_vtk: int = 0                               # animation (0: off, 1: init only, 2: all timesteps)
+    vtk_type: int = 3                                # surface and line meshes
+    transpose_dcm: int = 1                           # 0=false, 1=true
+
+#-------------------------------------------------------------------------------
+# Main driver class
+#-------------------------------------------------------------------------------
+class AeroDynDriver:
+    """Main driver class for AeroDyn simulation."""
+
+    def __init__(self, config: AeroDynConfig, lib_config: LibraryConfig):
+        """Initialize the AeroDyn driver with configuration settings."""
+        self.config = config
+        self.lib_config = lib_config
+
+        # Initialize mesh data structures
+        self._initialize_mesh_data()
+
+        # Initialize library
+        self.adilib = self._initialize_library()
+
+        # Initialize output arrays as placeholders
+        self.output_channel_values = None
+        self.all_output_channel_values = None
+
+    def _initialize_mesh_data(self) -> None:
+        """Initializes mesh data from VTK files for hub, nacelle, and blades.
+
+        Reads initial positions and orientations from VTK reference files and stores
+        them as class attributes for later use in the simulation.
+        """
+        # Initialize hub and nacelle positions
+        read_vtk_ref = lambda root_name: read_reference_positions_from_vtk(
+            os.path.sep.join([self.config.vtk_dir, root_name + "_Reference.vtp"])
+        )
+        self.init_hub_pos, self.init_hub_orient, num_pts = read_vtk_ref(
+            self.config.hub_mesh_root
+        )
+        self.init_nacelle_pos, self.init_nacelle_orient, num_pts = read_vtk_ref(
+            self.config.nac_mesh_root
+        )
+
+        # Initialize blade root positions and orientations
+        self.init_root_pos = np.zeros((self.config.num_blades, 3), dtype="float32")
+        self.init_root_orient = np.zeros((self.config.num_blades, 9), dtype="float64")
+        for i in range(self.config.num_blades):
+            self.init_root_pos[i,:], self.init_root_orient[i,:], num_pts = read_vtk_ref(
+                self.config.bld_root_mesh_root + str(i+1)
+            )
+
+        # Initialize blade mesh positions and orientations
+        self.num_blade_node = np.zeros((self.config.num_blades), dtype=int)
+        self.init_mesh_pos = np.empty((0, 3), dtype="float32")
+        self.init_mesh_orient = np.empty((0, 9), dtype="float64")
+        self.init_mesh_pt_to_blade_num = np.empty((0), dtype=int)
+
+        for i in range(self.config.num_blades):
+            tmp_pos, tmp_orient, num_pts = read_vtk_ref(
+                self.config.bld_mesh_root + str(i+1)
+            )
+            self.init_mesh_pos = np.concatenate((self.init_mesh_pos, tmp_pos))
+            self.init_mesh_orient = np.concatenate((self.init_mesh_orient, tmp_orient))
+            self.num_blade_node[i] = num_pts
+
+            # Store blade number for these points
+            tmp_pt_to_blade_num = np.full(num_pts, i+1, dtype=int)
+            self.init_mesh_pt_to_blade_num = np.concatenate(
+                (self.init_mesh_pt_to_blade_num, tmp_pt_to_blade_num)
+            )
+
+    def _initialize_library(self) -> adi.AeroDynInflowLib:
+        """Initialize the AeroDyn library with configuration settings."""
+        library_path = get_library_path(module_name="aerodyn")
+
+        try:
+            adilib = adi.AeroDynInflowLib(library_path)
+        except Exception as e:
+            print(f"Failed to load AeroDyn library at {library_path}: {e}")
+            sys.exit(1)
+
+        #--------------------------------------
+        # Configure library
+        #--------------------------------------
+        adilib.interpolation_order = self.lib_config.interpolation_order
+        adilib.dt = self.lib_config.dt
+        adilib.num_time_steps = self.config.time_steps_to_run
+        adilib.gravity = self.lib_config.gravity
+        adilib.fluid_density = self.lib_config.fluid_density
+        adilib.kinematic_viscosity = self.lib_config.kinematic_viscosity
+        adilib.sound_speed = self.lib_config.sound_speed
+        adilib.atmospheric_pressure = self.lib_config.atmospheric_pressure
+        adilib.vapor_pressure = self.lib_config.vapor_pressure
+        adilib.water_depth = self.lib_config.water_depth
+        adilib.mean_sea_level_offset = self.lib_config.mean_sea_level_offset
+        adilib.num_turbines = self.config.num_turbines
+
+        # Visualization settings
+        adilib.store_hub_height_velocity = self.lib_config.store_hub_height_velocity
+        adilib.write_vtk = self.lib_config.write_vtk
+        adilib.vtk_type = self.lib_config.vtk_type
+        adilib.transpose_dcm = self.lib_config.transpose_dcm
+
+        return adilib
+
+    def run_simulation(self) -> None:
+        """Run the main simulation with time stepping."""
+        # Initialize the simulation
+        self._initialize_simulation()
+
+        # Create time array
+        time = np.arange(0.0, (self.config.time_steps_to_run + 1) * self.adilib.dt, self.adilib.dt)
+
+        # Initialize debug output file if needed
+        debug_output_file = None
+        if self.config.debug_outputs == 1:
+            debug_output_file = adi.DriverDbg(self.config.debug_output_file, self.adilib.num_mesh_pts)
+
+        try:
+            # Process initial timestep
+            print(f"Time step: 0 at {time[0]}")
+            self._process_timestep(0, time[0], 0.0, debug_output_file)
+
+            # Time stepping loop
+            for i in range(1, len(time)):
+                print(f"Time step: {i} at {time[i]}")
+
+                # Correction loop if needed
+                for correction in range(self.config.num_corrections + 1):
+                    self._process_timestep(
+                        i_step=i,
+                        current_time=time[i],
+                        prev_time=time[i-1],
+                        debug_output_file=debug_output_file,
+                        correction_step=correction
+                    )
+
+        finally:
+            # Close debug output file if it was opened
+            if debug_output_file:
+                debug_output_file.end()
+
+            # End AeroDyn simulation
+            try:
+                self.adilib.adi_end()
+            except Exception as e:
+                print(f"Failed to end AeroDyn simulation: {e}")
+                sys.exit(1)
+
+        # Write output file with channel data
+        out_file = adi.WriteOutChans(
+            self.config.output_file,
+            self.adilib.output_channel_names,
+            self.adilib.output_channel_units
+        )
+        out_file.write(self.all_output_channel_values)
+        out_file.end()
+
+        print("Simulation completed successfully")
+
+    def _initialize_simulation(self) -> None:
+        """Initialize the AeroDyn simulation."""
+        # Set initial positions and orientations
+        self.adilib.init_hub_pos = self.init_hub_pos[0, :]
+        self.adilib.init_hub_orient = self.init_hub_orient[0, :]
+        self.adilib.init_nacelle_pos = self.init_nacelle_pos[0, :]
+        self.adilib.init_nacelle_orient = self.init_nacelle_orient[0, :]
+        self.adilib.num_blades = self.config.num_blades
+        self.adilib.init_root_pos = self.init_root_pos
+        self.adilib.init_root_orient = self.init_root_orient
+
+        # Set mesh data
+        self.adilib.num_mesh_pts = np.size(self.init_mesh_pos, 0)
+        self.adilib.init_mesh_pos = self.init_mesh_pos
+        self.adilib.init_mesh_orient = self.init_mesh_orient
+        self.adilib.mesh_pt_to_blade_num = self.init_mesh_pt_to_blade_num
+
+        # Pre-initialize the AeroDyn library
+        try:
+            self.adilib.adi_preinit()
+        except Exception as e:
+            print(f"Failed to pre-initialize AeroDyn: {e}")
+            sys.exit(1)
+
+        # Setup rotors
+        self._setup_rotors()
+
+        # Read input files
+        ad_input_lines = read_lines_from_file(self.config.primary_ad_file)
+        ifw_input_lines = read_lines_from_file(self.config.primary_ifw_file)
+
+        # Initialize AeroDyn
+        try:
+            self.adilib.adi_init(ad_input_lines, ifw_input_lines)
+        except Exception as e:
+            print(f"Failed to initialize AeroDyn: {e}")
+            sys.exit(1)
+
+        # Initialize output arrays
+        self.output_channel_values = np.zeros(self.adilib.num_channels)
+        self.all_output_channel_values = np.zeros((
+            self.config.time_steps_to_run + 1, self.adilib.num_channels + 1
+        ))
+
+    def _setup_rotors(self) -> None:
+        """Setup rotors for all turbines in the simulation."""
+        for i_turb in range(1, self.config.num_turbines + 1):
+            turb_ref_pos = [0, 0, 0]
+            try:
+                self.adilib.adi_setuprotor(i_turb, self.config.is_hawt, turb_ref_pos)
+            except Exception as e:
+                print(f"Failed to setup rotor for turbine {i_turb}: {e}")
+                sys.exit(1)
+
+    def _process_timestep(
+        self,
+        i_step: int,
+        current_time: float,
+        prev_time: float,
+        debug_output_file: Optional[adi.DriverDbg] = None,
+        correction_step: int = 0
+    ) -> None:
+        """Process a single timestep in the simulation."""
+        # Get motion data for current timestep
+        hub_pos, hub_orient, hub_vel, hub_acc = self._set_motion_hub(i_step)
+        nac_pos, nac_orient, nac_vel, nac_acc = self._set_motion_nacelle(i_step)
+        root_pos, root_orient, root_vel, root_acc = self._set_motion_root(i_step)
+        mesh_pos, mesh_orient, mesh_vel, mesh_acc, mesh_forces_moments = self._set_motion_blade_mesh(i_step)
+
+        # Create motion data objects
+        hub_motion = adi.MotionData(hub_pos, hub_orient, hub_vel, hub_acc)
+        nac_motion = adi.MotionData(nac_pos, nac_orient, nac_vel, nac_acc)
+        root_motion = adi.MotionData(root_pos, root_orient, root_vel, root_acc)
+        mesh_motion = adi.MotionData(mesh_pos, mesh_orient, mesh_vel, mesh_acc)
 
         # Set motions for rotor
+        i_turb = 1  # Hard-coded to one turbine for now
         try:
-            adilib.adi_setrotormotion(
-                    iturb,
-                    HubPos, HubOrient, HubVel, HubAcc,
-                    NacPos, NacOrient, NacVel, NacAcc,
-                    RootPos, RootOrient, RootVel, RootAcc,
-                    MeshPos_ar, MeshOrient_ar, MeshVel_ar, MeshAcc_ar)
+            self.adilib.adi_setrotormotion(
+                i_turb,
+                hub_motion,
+                nac_motion,
+                root_motion,
+                mesh_motion
+            )
         except Exception as e:
-            print("{}".format(e))
-            if DbgOuts == 1:
-                dbg_outfile.end()
-            #FIXME: temporary statement here
-            print("Exit after failed call to adi_setrotormotion at {time[i]}")
-            exit(1)
+            print(f"Failed to set rotor motion at T={current_time}: {e}")
+            raise
 
+        # Update states if not the first timestep
+        if i_step > 0 and correction_step == 0:
+            try:
+                self.adilib.adi_updateStates(prev_time, current_time)
+            except Exception as e:
+                print(f"Failed to update states at T={current_time}: {e}")
+                raise
 
-        #   Update the states from t to t+dt (only if not beyond end of sim)
+        # Calculate outputs
         try:
-            adilib.adi_updateStates(time[i-1], time[i])
+            self.adilib.adi_calcOutput(current_time, self.output_channel_values)
         except Exception as e:
-            print("{}".format(e))
-            if DbgOuts == 1:
-                dbg_outfile.end()
-            #FIXME: temporary statement here
-            print("Exit after failed call to adi_updateStates")
-            exit(1)
- 
-        # Calculate the outputs at t+dt
-        print(f"Time step: {i} at {time[i]}")
-        #       NOTE: new input values may be available at this point from the
-        #       structural solver, so update them here.
-        #   read position/motion from vtk
-        HubPos,  HubOrient,  HubVel,  HubAcc  = SetMotionHub(i)
-        NacPos,  NacOrient,  NacVel,  NacAcc  = SetMotionNac(i)
-        RootPos, RootOrient, RootVel, RootAcc = SetMotionRoot(i)
-        MeshPos_ar, MeshOrient_ar, MeshVel_ar, MeshAcc_ar, MeshFrcMom = SetMotionBlMesh(i)
+            print(f"Failed to calculate outputs at T={current_time}: {e}")
+            raise
 
-        # Set motions for rotor
+        # Get rotor loads
         try:
-            adilib.adi_setrotormotion(
-                    iturb,
-                    HubPos, HubOrient, HubVel, HubAcc,
-                    NacPos, NacOrient, NacVel, NacAcc,
-                    RootPos, RootOrient, RootVel, RootAcc,
-                    MeshPos_ar, MeshOrient_ar, MeshVel_ar, MeshAcc_ar)
+            self.adilib.adi_getrotorloads(i_turb, mesh_forces_moments)
         except Exception as e:
-            print("{}".format(e))
-            if DbgOuts == 1:
-                dbg_outfile.end()
-            #FIXME: temporary statement here
-            print("Exit after failed call to adi_setrotormotion at {time[i]}")
-            exit(1)
+            print(f"Failed to get rotor loads at T={current_time}: {e}")
+            raise
 
+        # Write debug output if enabled
+        if debug_output_file:
+            debug_output_file.write(current_time, mesh_pos, mesh_vel, mesh_acc, mesh_forces_moments)
 
-        try:
-            adilib.adi_calcOutput(time[i], outputChannelValues)
-        except Exception as e:
-            print("{}".format(e))
-            if DbgOuts == 1:
-                dbg_outfile.end()
-            #FIXME: temporary statement here
-            print(f"Exit after failed call to adi_calcOutput at time {time[i]}")
-            exit(1)
+        # Store outputs
+        self.all_output_channel_values[i_step, :] = np.append(current_time, self.output_channel_values)
 
-        # get resulting forces
-        try:
-            adilib.adi_getrotorloads(
-                    iturb,
-                    MeshFrcMom)
-        except Exception as e:
-            print("{}".format(e))
-            if DbgOuts == 1:
-                dbg_outfile.end()
-            #FIXME: temporary statement here
-            print("Exit after failed call to adi_getrotorloads at {time[i]}")
-            exit(1)
+    def _set_motion_hub(self, i_timestep: int) -> tuple:
+        """Gets hub motion parameters for the current time step.
 
- 
-## Write the debug output at t=t_initial
- 
-        #   When coupled to a different code, this is where the Force/Moment info
-        #   would be passed to the aerodynamic solver.
-        #
-        #   For this regression test example, we will write this to file (in
-        #   principle this could be aggregated and written out once at the end of
-        #   the regression simulation, but for simplicity we are writting one line
-        #   at a time during the call).  The regression test will have one row for
-        #   each timestep + position array entry.
-        if DbgOuts == 1:
-            dbg_outfile.write(time[i],MeshPos_ar,MeshVel_ar,MeshAcc_ar,MeshFrcMom)
+        Args:
+            i_timestep: Current time step number
 
+        Returns:
+            tuple: (hub_position, hub_orientation, hub_velocity, hub_acceleration)
+        """
+        return read_vtk_motion(
+            self.config.vtk_dir, self.config.hub_mesh_root, i_timestep, self.config.vtk_field_len
+        )
 
-    # Store the channel outputs -- these are requested from within the IfW input
-    # file OutList section.  In OpenFAST, these are added to the output
-    # channel array for all modules and written to that output file.  For this
-    # example we will write to file at the end of the simulation in a single
-    # shot.
-    allOutputChannelValues[i,:] = np.append(time[i],outputChannelValues)
+    def _set_motion_nacelle(self, i_timestep: int) -> tuple:
+        """Gets nacelle motion parameters for the current time step.
 
+        Args:
+            i_timestep: Current time step number
 
-if DbgOuts == 1:
-    dbg_outfile.end()   # close the debug output file
+        Returns:
+            tuple: (nacelle_position, nacelle_orientation, nacelle_velocity, nacelle_acceleration)
+        """
+        return read_vtk_motion(
+            self.config.vtk_dir, self.config.nac_mesh_root, i_timestep, self.config.vtk_field_len
+        )
 
-# if we got this far, things must have succeeded
-print("Simulation completed sucessfully")
+    def _set_motion_root(self, i_timestep: int) -> tuple:
+        """Gets blade root motion parameters for the current time step.
 
+        Args:
+            i_timestep: Current time step number
 
-# adi_end: Only need to call aerodyn_inflow_end once.
-#   NOTE:   in the event of an error during the above Init or CalcOutput calls,
-#           the IfW_End routine will be called during that error handling.
-#           This works for IfW, but may not be a desirable way to handle
-#           errors in other codes (we may still want to retrieve some info
-#           from memory before clearing out everything).
-#   NOTE:   Error handling from the adi_end call may not be entirely
-#           necessary, but we may want to know if some memory was not released
-#           properly or a file not closed correctly.
-try:
-    adilib.adi_end()
-except Exception as e:
-    print("{}".format(e))
-    #FIXME: temporary statement here
-    print("Exit after failed call to adi_end")
-    exit(1)
+        Returns:
+            tuple: (root_positions, root_orientations, root_velocities, root_accelerations)
+        """
+        root_positions = np.zeros((self.config.num_blades, 3), dtype="float32")
+        root_orientations = np.zeros((self.config.num_blades, 9), dtype="float64")
+        root_velocities = np.zeros((self.config.num_blades, 6), dtype="float32")
+        root_accelerations = np.zeros((self.config.num_blades, 6), dtype="float32")
 
+        for k in range(self.config.num_blades):
+            positions, orientations, velocities, accelerations = read_vtk_motion(
+                self.config.vtk_dir,
+                self.config.bld_root_mesh_root + str(k+1),
+                i_timestep,
+                self.config.vtk_field_len
+            )
+            root_positions[k, :] = positions
+            root_orientations[k, :] = orientations
+            root_velocities[k, :] = velocities
+            root_accelerations[k, :] = accelerations
 
-#   Now write the ouput channels to a file
-OutFile=adi.WriteOutChans(output_file,adilib.output_channel_names,adilib.output_channel_units)
-OutFile.write(allOutputChannelValues)
-OutFile.end()
+        return root_positions, root_orientations, root_velocities, root_accelerations
 
+    def _set_motion_blade_mesh(self, i_timestep: int) -> tuple:
+        """Gets blade mesh motion parameters for the current time step.
 
+        Args:
+            i_timestep: Current time step number
 
-#print("HydroDyn successful.")
-exit()
+        Returns:
+            tuple: (mesh_positions, mesh_orientations, mesh_velocities, mesh_accelerations, mesh_forces_moments)
+        """
+        mesh_positions = np.empty((0, 3), dtype="float32")
+        mesh_orientations = np.empty((0, 9), dtype="float64")
+        mesh_velocities = np.empty((0, 6), dtype="float32")
+        mesh_accelerations = np.empty((0, 6), dtype="float32")
+        mesh_forces_moments = np.zeros((sum(self.num_blade_node), 6))  # [Fx, Fy, Fz, Mx, My, Mz]
 
+        for k in range(self.config.num_blades):
+            positions, orientations, velocities, accelerations = read_vtk_motion(
+                self.config.vtk_dir,
+                self.config.bld_mesh_root + str(k+1),
+                i_timestep,
+                self.config.vtk_field_len
+            )
+            mesh_positions = np.concatenate((mesh_positions, positions))
+            mesh_orientations = np.concatenate((mesh_orientations, orientations))
+            mesh_velocities = np.concatenate((mesh_velocities, velocities))
+            mesh_accelerations = np.concatenate((mesh_accelerations, accelerations))
+
+        return mesh_positions, mesh_orientations, mesh_velocities, mesh_accelerations, mesh_forces_moments
+
+if __name__ == "__main__":
+    driver = AeroDynDriver(AeroDynConfig(), LibraryConfig())
+    driver.run_simulation()

--- a/modules/driver_utilities.py
+++ b/modules/driver_utilities.py
@@ -3,6 +3,48 @@ import sys
 from pathlib import Path
 from visread import *
 
+def get_library_path(module_name: str) -> str:
+    """Determines the correct library path based on platform and module name.
+
+    Args:
+        module_name: Name of the module
+
+    Returns:
+        str: Path to the module library for the current platform.
+
+    Raises:
+        ValueError: If the current platform is not supported.
+        SystemExit: If on Windows and the DLL cannot be found in expected locations.
+    """
+    # Map module names to their library base names
+    module_map = {
+        "aerodyn": "libaerodyn_inflow_c_binding",
+        "hydrodyn": "libhydrodyn_c_binding",
+        "inflowwind": "libifw_c_binding",
+        "moordyn": "libmoordyn_c_binding"
+    }
+    basename = module_map.get(module_name.lower(), f"lib{module_name}_c_binding")
+    build_path = Path("..").joinpath(*[".."] * 4, "build")
+
+    if sys.platform in ["linux", "linux2"]:
+        return str(build_path / "modules" / module_name / f"{basename}.so")
+
+    if sys.platform == "darwin":
+        return str(build_path / "modules" / module_name / f"{basename}.dylib")
+
+    if sys.platform == "win32":
+        bit_version = "Win32" if sys.maxsize <= 2**32 else "x64"
+        possible_paths = [
+            build_path / "modules" / module_name / f"{basename}.dll",
+            build_path / "bin" / f"{module_name}_c_binding_{bit_version}.dll"
+        ]
+        return str(next((path for path in possible_paths if path.is_file()), None)) or sys.exit(
+            f"Python is {bit_version} bit and cannot find {bit_version} "
+            f"bit {module_name} DLL in any expected location."
+        )
+
+    raise ValueError(f"Unsupported platform: {sys.platform}")
+
 def read_lines_from_file(file_path: str) -> list[str]:
     """Reads a file line by line, stripping whitespace.
 
@@ -32,34 +74,40 @@ def read_vtk_motion(vtk_dir: str, base_name: str, time_step: int, field_len: int
     velocities, accelerations = read_velocities_and_accelerations_from_vtk(file_path, num_pts)
     return positions, orientations, velocities, accelerations
 
-def get_library_path() -> str:
-    """Determines the correct library path based on platform.
+def read_positions_from_file(file_path: str) -> np.ndarray:
+    """Reads initial position of points from a file.
+
+    The file should contain a list of X,Y,Z coordinates in the OpenFAST global/inertial
+    coordinate system, with one point per line. Lines starting with '#' are treated as
+    comments and ignored. Each line should contain exactly 3 space-separated floating
+    point values representing the X, Y, and Z coordinates respectively.
+
+    Example format:
+        #  x     y     z
+        0.0  0.0  150.0
+        0.0  0.0  125.0
+        0.0  0.0  175.0
+        0.0  25.0 150.0
+        0.0 -25.0 150.0
+
+    Args:
+        file_path: Path to the positions file
 
     Returns:
-        str: Path to the AeroDyn library for the current platform.
+        numpy.ndarray: Array of position points (Nx3) where N is the number of points
+        and each point has [X,Y,Z] coordinates
 
     Raises:
-        ValueError: If the current platform is not supported.
-        SystemExit: If on Windows and the DLL cannot be found in expected locations.
+        ValueError: If positions file format is invalid (doesn't contain exactly 3 values per line)
     """
-    basename = "libaerodyn_inflow_c_binding"
-    build_path = Path("..").joinpath(*[".."] * 4, "build")
+    positions = []
+    with open(file_path, "r") as fh:
+        for line in fh:
+            if not line.startswith('#'):
+                positions.append([float(i) for i in line.split()])
 
-    if sys.platform in ["linux", "linux2"]:
-        return str(build_path / "modules" / "aerodyn" / f"{basename}.so")
+    positions = np.asarray(positions)
+    if positions.shape[1] != 3:
+        raise ValueError("Error in parsing points file. Does not contain a Nx3 set of position points")
 
-    if sys.platform == "darwin":
-        return str(build_path / "modules" / "aerodyn" / f"{basename}.dylib")
-
-    if sys.platform == "win32":
-        bit_version = "Win32" if sys.maxsize <= 2**32 else "x64"
-        possible_paths = [
-            build_path / "modules" / "aerodyn" / f"{basename}.dll",
-            build_path / "bin" / f"AeroDyn_Inflow_c_binding_{bit_version}.dll"
-        ]
-        return str(next((path for path in possible_paths if path.is_file()), None)) or sys.exit(
-            f"Python is {bit_version} bit and cannot find {bit_version} "
-            f"bit InflowWind DLL in any expected location."
-        )
-
-    raise ValueError(f"Unsupported platform: {sys.platform}")
+    return positions

--- a/modules/driver_utilities.py
+++ b/modules/driver_utilities.py
@@ -28,8 +28,8 @@ def read_vtk_motion(vtk_dir: str, base_name: str, time_step: int, field_len: int
     """
     time_field = str(time_step).zfill(field_len)
     file_path = os.path.sep.join([vtk_dir, f"{base_name}.{time_field}.vtp"])
-    positions, orientations, num_pts = visread_positions(file_path)
-    velocities, accelerations = visread_velacc(file_path, num_pts)
+    positions, orientations, num_pts = read_current_positions_from_vtk(file_path)
+    velocities, accelerations = read_velocities_and_accelerations_from_vtk(file_path, num_pts)
     return positions, orientations, velocities, accelerations
 
 def get_library_path() -> str:

--- a/modules/driver_utilities.py
+++ b/modules/driver_utilities.py
@@ -1,0 +1,65 @@
+import os
+import sys
+from pathlib import Path
+from visread import *
+
+def read_lines_from_file(file_path: str) -> list[str]:
+    """Reads a file line by line, stripping whitespace.
+
+    Args:
+        file_path: Path to the file to read
+
+    Returns:
+        List of stripped lines from the file
+    """
+    return [line.rstrip() for line in open(file_path, "r")]
+
+def read_vtk_motion(vtk_dir: str, base_name: str, time_step: int, field_len: int) -> tuple:
+    """Reads position, orientation, velocity, and acceleration from a VTK file.
+
+    Args:
+        vtk_dir: Directory containing VTK files
+        base_name: Base name of the VTK file
+        time_step: Current time step number
+        field_len: Length of the time field in filename
+
+    Returns:
+        tuple: (positions, orientations, velocities, accelerations)
+    """
+    time_field = str(time_step).zfill(field_len)
+    file_path = os.path.sep.join([vtk_dir, f"{base_name}.{time_field}.vtp"])
+    positions, orientations, num_pts = visread_positions(file_path)
+    velocities, accelerations = visread_velacc(file_path, num_pts)
+    return positions, orientations, velocities, accelerations
+
+def get_library_path() -> str:
+    """Determines the correct library path based on platform.
+
+    Returns:
+        str: Path to the AeroDyn library for the current platform.
+
+    Raises:
+        ValueError: If the current platform is not supported.
+        SystemExit: If on Windows and the DLL cannot be found in expected locations.
+    """
+    basename = "libaerodyn_inflow_c_binding"
+    build_path = Path("..").joinpath(*[".."] * 4, "build")
+
+    if sys.platform in ["linux", "linux2"]:
+        return str(build_path / "modules" / "aerodyn" / f"{basename}.so")
+
+    if sys.platform == "darwin":
+        return str(build_path / "modules" / "aerodyn" / f"{basename}.dylib")
+
+    if sys.platform == "win32":
+        bit_version = "Win32" if sys.maxsize <= 2**32 else "x64"
+        possible_paths = [
+            build_path / "modules" / "aerodyn" / f"{basename}.dll",
+            build_path / "bin" / f"AeroDyn_Inflow_c_binding_{bit_version}.dll"
+        ]
+        return str(next((path for path in possible_paths if path.is_file()), None)) or sys.exit(
+            f"Python is {bit_version} bit and cannot find {bit_version} "
+            f"bit InflowWind DLL in any expected location."
+        )
+
+    raise ValueError(f"Unsupported platform: {sys.platform}")

--- a/modules/inflowwind/py_ifw_turbsimff/py_ifw_driver.py
+++ b/modules/inflowwind/py_ifw_turbsimff/py_ifw_driver.py
@@ -1,8 +1,9 @@
-#**********************************************************************************************************************************
+#-------------------------------------------------------------------------------
 # LICENSING
-# Copyright (C) 2021 National Renewable Energy Lab
+#-------------------------------------------------------------------------------
+# Copyright (C) 2021-present by National Renewable Energy Lab (NREL)
 #
-# This file is a test case for the InflowWind C-bindings library with python 
+# This file is part of InflowWind
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,299 +16,315 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+#-------------------------------------------------------------------------------
+# Overview of InflowWind python driver
+#-------------------------------------------------------------------------------
+# This script serves as a Python driver for the InflowWind library. It demonstrates
+# how to interact with the main subroutines of InflowWind.
 #
-#**********************************************************************************************************************************
+# NOTE: This script serves as a template and can be customized to meet
+# individual requirements.
 #
-# This is an example of Python driver code for InflowWind
-#
-# Usage: This program gives an example for how the user calls the main
-#        subroutines of inflowWind, and thus is specific to the user
-#
-# Basic alogrithm for using InflowWind python library
-#   1.  initialize python wrapper library
-#           set necessary library values
-#               numWindPts
-#               dt
-#               numTimeSteps
-#           set input file string arrays (from file or script)
-#   2.  initialize InflowWind Fortran library
-#           call ifw_init once to initialize IfW
-#           Handle any resulting errors
-#   3.  timestep iteration
-#           set array of positions to pass
-#           call ifw_calcoutput.  Handle any resulting errors
-#           return the resulting velocities array
-#           aggregate output channnels
-#   4. End
-#         call ifw_end to close the InflowWind library and free memory
-#         handle any resulting errors
-#
-#
-import numpy as np
+# Basic algorithm for using InflowWind python library:
+#   1. Initialize the Python wrapper library:
+#      - Set necessary library values (e.g., numWindPts, dt, numTimeSteps)
+#      - Load input file data (from file/script)
+#   2. Initialize the InflowWind Fortran library:
+#      - Call ifw_init once
+#      - Handle any resulting errors
+#   3. Timestep Iterations:
+#      - Set array of positions
+#      - Call ifw_calcoutput and handle errors
+#      - Return resulting velocities array
+#      - Aggregate output channels
+#   4. Finalize:
+#      - Call ifw_end to close library and release resources
+#      - Handle any resulting errors
+
+#-------------------------------------------------------------------------------
+# Imports
+#-------------------------------------------------------------------------------
 import os
 import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
 
-# path to find the inflowwind_library.py from the local directory
-os.chdir(sys.path[0])
-ifwLibPath=os.path.sep.join(["..", "..", "..", "..", "..", "modules", "inflowwind", "python-lib"])
-sys.path.insert(0, ifwLibPath)
-print(f"Importing 'inflowwind_library' from {ifwLibPath}")
-import inflowwind_library # this file handles the conversion from python to c-bound types and should not be changed by the user
+import numpy as np
 
-###############################################################################
-# Locations to build directory relative to r-test directory.  This is specific
-# to the regession testing with openfast and will need to be updated when
-# coupled to other codes or use cases
-
-basename = "libifw_c_binding"
-if sys.platform == "linux" or sys.platform == "linux2":
-    library_path = os.path.sep.join(["..", "..", "..", "..", "..", "build", "modules", "inflowwind", basename + ".so"])
-elif sys.platform == "darwin":
-    library_path = os.path.sep.join(["..", "..", "..", "..", "..", "build", "modules", "inflowwind", basename + ".dylib"])
-elif sys.platform == "win32":
-    # Windows may have this library installed in one of two locations depending
-    # on which build system was used (CMake or VS).
-    library_path = os.path.sep.join(["..", "..", "..", "..", "..", "build", "modules", "inflowwind", basename + ".dll"])   # cmake install location
-    if not os.path.isfile(library_path) and not sys.maxsize > 2**32:        # Try VS build location otherwise
-        library_path = os.path.sep.join(["..", "..", "..", "..", "..", "build", "bin", "InflowWind_c_binding_Win32.dll"]) # VS build install location
-        if not os.path.isfile(library_path):
-            print(f"Python is 32 bit and cannot find 32 bit InflowWind DLL expected at: {library_path}")
-            exit(1)
-    if not os.path.isfile(library_path) and sys.maxsize > 2**32:        # Try VS build location otherwise
-        library_path = os.path.sep.join(["..", "..", "..", "..", "..", "build", "bin", "InflowWind_c_binding_x64.dll"]) # VS build install location
-        if not os.path.isfile(library_path):
-            print(f"Python is 64 bit and cannot find 64 bit InflowWind DLL expected at: {library_path}")
-            exit(1)
-
-
-
-###############################################################################
-# For testing, a set of input files is read in.  Everything in these input
-# files could in principle be hard coded into this script.  These are separated
-# out for convenience in testing.
-
-#   Primary input
-#       This is identical to what InflowWind would read from disk if we were
-#       not passing it.  When coupled to other codes, this may be passed
-#       directly from memory (i.e. during optimization with WEIS), or read as a
-#       template and edited in memory for each iteration loop.
-primary_ifw_file="ifw_primary.inp"
-
-#   Positions array
-#       When coupled to another code, an array of positions (N points of
-#       [X,Y,Z] values) would be passed from the structural code.  Since this
-#       driver is standalone, we will read in an array of points that will be
-#       passed through to InflowWind at each timestep.  This is read in from
-#       disk once at the start of this code into the positions array.  When
-#       coupled to other codes, this file would not exist.
-position_file="Points.inp"
-
-#   Velocities array output file
-#       When coupled into another code, an array of velocities would be
-#       returned corresponding to the positions array passed in.  For testing
-#       purposes, we will write these values to disk.  When coupled to other
-#       codes, this file would not exist.
-velocities_file="Points.Velocity.dat"
-
-#   Output file
-#       When coupled to another code, the channels requested in the outlist
-#       section of the output file are passed back for writing to file.  Here
-#       we will write the aggregated output channels to a file at the end of
-#       the simulation.
-output_file="ifw_primary.out"
-
-
-#------------------------------------------------------- INPUT FILES ---------------------------------------------------------
-#=============================================================================================================================
-
-#   Main inflowWind input file
-#       For testing, we read in the file from disk and store it in an array of
-#       strings with the line endings stripped off.  This array will be have
-#       the same number of elements as there are lines in the file.
-ifw_input_string_array = []     # instantiate empty array
-fh = open(primary_ifw_file, "r")
-for line in fh:
-  # strip line ending and ending white space and add to array of strings
-  ifw_input_string_array.append(line.rstrip())
-fh.close()
-
-#=============================================================================================================================
-#----------------------------------------------------- FUNCTION CALLS --------------------------------------------------------
-#=============================================================================================================================
-
-#   Instantiate the ifwlib python object
-#       wrap this in error handling in case the library_path is incorrect
-try:
-    ifwlib = inflowwind_library.InflowWindLib(library_path)
-except Exception as e:
-    # Do any clean up and final output
-    print("{}".format(e))
-    print(f"Cannot load library at {library_path}")
-    exit(1)
-
-#   Time inputs
-#       For this test case, we are checking between 30 and 30.8 seconds.  The
-#       inflowwind python library interface must be informed about the
-#       following 2 time related information variables
-#           ifwlib.dt           -- the timestep inflowwind is called at.
-#           ifwlib.numTimeSteps -- total number of timesteps, only used to
-#                                  construct arrays to hold the output channel
-#                                  info
-t_start             = 30                 # initial time
-ifwlib.dt           = 0.1                # time interval that it's being called at, not usedby IFW, only here for consistency with other modules
-final_time          = 30.8               # final time
-time                = np.linspace(t_start, final_time, 9) # total time + increment because python doesnt include endpoint!
-ifwlib.numTimeSteps = len(time)          # only for constructing array of output channels for duration of simulation
-
-#   Test passing of filename, uncomment next two lines
-#ifw_input_string_array=[primary_ifw_file];
-#ifwlib.IfWinputPass = 0
-
-# debugging of internals of ADI library
-ifwlib.debuglevel   = 3         # 0-4
-
-#   Initialize position array 
-#       For testing, a set of points is read from the position_file and stored
-#       as a N x 3 ([x, y, z]).  These coordinates are in the openfast global
-#       coordinate system (aka inertial coordinates).  In this test case, these
-#       values are read in once at the begining, and held constant at each
-#       timestep call.  These could be hard coded as a smaller set of points
-#       for testing, but this test is designed to match an equivalent fortran
-#       driver test as a way to verify that the coupling from python through
-#       fortran and back is correct.
+# Path to find the inflowwind_library.py from the local directory
 #
-#           positions = np.array([  # position array originally used in develop
-#               [0.0,  0.0, 150],
-#               [0.0,  0.0, 125],
-#               [0.0,  0.0, 175],
-#               [0.0,  25., 150],
-#               [0.0, -25., 150],
-#               [0.0,  25., 175],
-#               [0.0, -25., 175],
-#               [0.0,  25., 125],
-#               [0.0, -25., 125]
-#           ])
-#
-#       When coupled to a different code, this array would be passed from the
-#       structural solver with the X,Y,Z points for location the wind velocity
-#       is needed (i.e. nodes on a rotor).  As the simulation progresses, these
-#       positions would change.  However, the number of points that wind data
-#       is requested for must be the same throughout the simulation (in other
-#       words, don't change the size of this array between calls to IfW).
-positions=[]
-fh=open(position_file, "r")
-for line in fh:
-    if not line.startswith('#'):
-        positions.append([float(i) for i in line.split()])
-positions = np.asarray(positions)
-fh.close()
+# NOTE: This file handles the conversion from python to c-bound types
+#       and should NOT be changed by the user
+os.chdir(Path(__file__).parent)
+ifw_lib_path = Path(__file__).parent.joinpath(*[".."]*5, "modules", "inflowwind", "python-lib")
+sys.path.insert(0, str(ifw_lib_path))
+print(f"Importing 'inflowwind_library' from {ifw_lib_path}")
+import inflowwind_library as ifw
 
-#  Check that the array is of the correct shape
-if positions.shape[1] != 3:
-    raise ValueError("Error in parsing the points file. Does not contain a Nx3 set of position points")
-
-#  numWindPts
-ifwlib.numWindPts   = positions.shape[0]              # total number of wind points requesting velocities for at each time step. must be integer
-
-#  Matching velocities array for the velocities reported from IfW
-velocities          = np.zeros((ifwlib.numWindPts,3)) # output velocities (N x 3) - also in openfast global coordinate system
-
-
-#==============================================================================
-# Basic alogrithm for using InflowWind library
-#
-# NOTE: the error handling here is handled locally since this is the only
-#       driver code.  If InflowWind is incorporated into another code, the
-#       error handling will need to be passed to the calling-code so that
-#       it can close other modules as necessary (otherwise you will end
-#       up with memory leaks and a bunch of garbage in the other library
-#       instances).
-
-# IFW_INIT: Only need to call ifw_init once
-try:
-    ifwlib.ifw_init(ifw_input_string_array)
-except Exception as e:
-    # Do any required clean up
-    print("{}".format(e))   # Exception is from inflowwind_library.py
-    exit(1)
-
-
-#  To get the names and units of the output channels
-#output_channel_names = ifwlib.output_channel_names
-#output_channel_units = ifwlib.output_channel_units
-
-
-#  Set the array holding the ouput channel values to zeros initially.  Output
-#  channel values returned from each CalcOutput call in this array.  We will
-#  aggregate them together in the time stepping loop to get the entire time
-#  series.  Time channel is not included, so we must add that.
-outputChannelValues = np.zeros(ifwlib.numChannels)
-allOutputChannelValues = np.zeros( (ifwlib.numTimeSteps,ifwlib.numChannels+1) )
-
-
-#   Open debug output file for regession testing purposes.
-DbgOutfile = inflowwind_library.DebugOut(velocities_file,ifwlib.numWindPts)
-
-
-#   Timestep iteration
-#       Step through all the timesteps.
-#           1.  set the positions array with node positions from the structural
-#               solver
-#           2.  call Ifw_CalcOutput_C to retreive the corresponding velocities
-#               to pass back to the calling code (or write to disk in this
-#               example).
-#
-for i, t in enumerate(time):
-
-    #   When coupled to another code, set the positions info for this timestep
-    #   here in the calling algorithm.  For this regression test example, the
-    #   positions are kept constant throughout the simulation.
-
-    try:
-        ifwlib.ifw_calc_output(t, positions, velocities, outputChannelValues)
-    except Exception as e:
-        print("{}".format(e))
-        DbgOutfile.end()
-        exit(1)
-    
-
-    #   When coupled to a different code, this is where the velocity info would
-    #   be passed to the aerodynamic solver.
+#-------------------------------------------------------------------------------
+# Configuration classes containing problem inputs
+#-------------------------------------------------------------------------------
+@dataclass
+class InflowWindConfig:
+    """Configuration settings for InflowWind simulation."""
+    # Time settings
     #
-    #   For this regression test example, we will write this to file (in
-    #   principle this could be aggregated and written out once at the end of
-    #   the regression simulation, but for simplicity we are writting one line
-    #   at a time during the call).  The regression test will have one row for
-    #   each timestep + position array entry.
-    DbgOutfile.write(t, positions, velocities)
+    # For this test case, we are checking between 30 and 30.8 seconds.  The
+    # inflowwind python library interface must be informed about the
+    # following 2 time related information variables
+    #   - ifwlib.dt -> timestep inflowwind is called at
+    #   - ifwlib.numTimeSteps -> total number of timesteps, used to construct
+    #     arrays to hold the output channel
+    t_start: float = 30.    # initial time
+    t_final: float = 30.8   # final time
+    dt: float = 0.1         # time interval that ifw is being called at
+
+    # Debug settings
+    debug_level: int = 3  # 0-4
+
+    # File paths
+    #
+    # Primary input: This is identical to what InflowWind would read from disk if we were not
+    # passing it. When coupled to other codes, this may be passed directly from memory (i.e.
+    # during optimization with WEIS), or read as a template and edited in memory for each
+    # iteration loop.
+    primary_ifw_file: str = "ifw_primary.inp"
+
+    # Position input: Contains an array of points (Nx3 [X,Y,Z] values) that will be passed to
+    # InflowWind at each timestep. When coupled to other codes, these positions would be passed
+    # directly from the structural code instead of reading from a file.
+    position_file: str = "Points.inp"
+
+    # Velocities output: For testing/debugging, the calculated velocities at each position point
+    # are written to this file. When coupled to other codes, these velocities would be returned
+    # directly to the calling code instead of writing to file.
+    velocities_file: str = "Points.Velocity.dat"
+
+    # Output channels: Contains the aggregated output channels requested in the outlist section.
+    # When coupled to other codes, these values could be passed back for writing by the calling
+    # code instead of writing directly to file here.
+    output_file: str = "ifw_primary.out"
+
+#-------------------------------------------------------------------------------
+# Helper functions
+#-------------------------------------------------------------------------------
+def read_lines_from_file(file_path: str) -> List[str]:
+    """Reads a file line by line, stripping whitespace.
+
+    Args:
+        file_path: Path to the file to read
+
+    Returns:
+        List of stripped lines from the file
+    """
+    with open(file_path, "r") as fh:
+        return [line.rstrip() for line in fh]
+
+def read_positions_from_file(file_path: str) -> np.ndarray:
+    """Reads initial position of points from a file.
+
+    The file should contain a list of X,Y,Z coordinates in the OpenFAST global/inertial
+    coordinate system, with one point per line. Lines starting with '#' are treated as
+    comments and ignored. Each line should contain exactly 3 space-separated floating
+    point values representing the X, Y, and Z coordinates respectively.
+
+    Example format:
+        #  x     y     z
+        0.0  0.0  150.0
+        0.0  0.0  125.0
+        0.0  0.0  175.0
+        0.0  25.0 150.0
+        0.0 -25.0 150.0
+
+    Args:
+        file_path: Path to the positions file
+
+    Returns:
+        numpy.ndarray: Array of position points (Nx3) where N is the number of points
+        and each point has [X,Y,Z] coordinates
+
+    Raises:
+        ValueError: If positions file format is invalid (doesn't contain exactly 3 values per line)
+    """
+    positions = []
+    with open(file_path, "r") as fh:
+        for line in fh:
+            if not line.startswith('#'):
+                positions.append([float(i) for i in line.split()])
+
+    positions = np.asarray(positions)
+    if positions.shape[1] != 3:
+        raise ValueError("Error in parsing points file. Does not contain a Nx3 set of position points")
+
+    return positions
+
+def get_library_path() -> str:
+    """Determines the correct library path based on platform.
+
+    Returns:
+        str: Path to the InflowWind library for the current platform
+
+    Raises:
+        SystemExit: If library cannot be found
+    """
+    basename = "libifw_c_binding"
+    build_path = Path("..").joinpath(*[".."] * 4, "build")
+
+    if sys.platform in ["linux", "linux2"]:
+        return str(build_path / "modules" / "inflowwind" / f"{basename}.so")
+
+    if sys.platform == "darwin":
+        return str(build_path / "modules" / "inflowwind" / f"{basename}.dylib")
+
+    if sys.platform == "win32":
+        # Try CMake location first
+        dll_path = build_path / "modules" / "inflowwind" / f"{basename}.dll"
+        if dll_path.is_file():
+            return str(dll_path)
+
+        # Try VS build location if CMake location not found
+        bit_version = "Win32" if not sys.maxsize > 2**32 else "x64"
+        vs_path = build_path / "bin" / f"InflowWind_c_binding_{bit_version}.dll"
+
+        if not vs_path.is_file():
+            print(f"Python is {bit_version} and cannot find {bit_version} InflowWind DLL")
+            sys.exit(1)
+        return str(vs_path)
+
+#-------------------------------------------------------------------------------
+# Main driver class
+#-------------------------------------------------------------------------------
+class InflowWindDriver:
+    """Main driver class for InflowWind simulation."""
+
+    def __init__(self, config: InflowWindConfig):
+        """Initialize the InflowWind driver.
+
+        Args:
+            config: Configuration settings for the simulation
+        """
+        self.config = config
+
+        # Initialize data structures
+        self.positions = read_positions_from_file(self.config.position_file)
+        self.velocities = np.zeros((self.positions.shape[0], 3))
+        self.time = np.linspace(
+            self.config.t_start,
+            self.config.t_final,
+            int((self.config.t_final - self.config.t_start) / self.config.dt) + 1 # 9
+        )
+
+        # Initialize library
+        self.ifwlib = self._initialize_library()
+
+    def _initialize_library(self) -> ifw.InflowWindLib:
+        """Initialize the InflowWind library with configuration settings.
+
+        Returns:
+            Configured instance of the InflowWind library
+
+        Raises:
+            SystemExit: If library initialization fails
+        """
+        try:
+            ifwlib = ifw.InflowWindLib(get_library_path())
+        except Exception as e:
+            print(f"Failed to load library: {e}")
+            sys.exit(1)
+
+        # Configure library
+        #
+        # ifwlib.dt -> timestep inflowwind is called at
+        ifwlib.dt = self.config.dt
+        # ifwlib.numTimeSteps -> total number of timesteps, used to construct arrays to hold the output channel
+        ifwlib.numTimeSteps = len(self.time)
+        # ifwlib.numWindPts -> total number of wind points requesting velocities for at each time step
+        ifwlib.numWindPts = self.positions.shape[0]
+        # ifwlib.debuglevel -> debug level for IfW library
+        ifwlib.debuglevel = self.config.debug_level
+
+        return ifwlib
+
+    def run_simulation(self) -> None:
+        """Run the main simulation loop."""
+        # Initialize output arrays
+        output_channel_values = None
+        all_output_channel_values = None
+
+        # Read input file
+        ifw_input = read_lines_from_file(self.config.primary_ifw_file)
+
+        # Initialize debug output if needed
+        debug_output = ifw.DebugOut(
+            self.config.velocities_file,
+            self.ifwlib.numWindPts
+        )
+
+        try:
+            # Initialize InflowWind -> only need to call it once
+            self.ifwlib.ifw_init(ifw_input)
+
+            # Initialize output arrays
+            output_channel_values = np.zeros(self.ifwlib.numChannels)
+            all_output_channel_values = np.zeros((len(self.time), self.ifwlib.numChannels + 1))
 
 
-    # Store the channel outputs -- these are requested from within the IfW input
-    # file OutList section.  In OpenFAST, these are added to the output
-    # channel array for all modules and written to that output file.  For this
-    # example we will write to file at the end of the simulation in a single
-    # shot.
-    allOutputChannelValues[i,:] = np.append(t, outputChannelValues)
+            # Time stepping loop: step through all the timesteps
+            #   1. Set the positions array with node positions from the structural solver
+            #   2. Call ifw_calc_output to retrieve the corresponding velocities
+            #      to pass back to the calling code (or write to disk in this example)
+            for i, t in enumerate(self.time):
+                # NOTE: When coupled to another code, set the positions info for this
+                # timestep here in the calling algorithm. For this regression test example,
+                # the positions are kept constant throughout the simulation.
 
+                try:
+                    self.ifwlib.ifw_calc_output(
+                        t,
+                        self.positions,
+                        self.velocities,
+                        output_channel_values
+                    )
+                except Exception as e:
+                    print(f"Error in calculation at t={t}: {e}")
+                    raise
 
-DbgOutfile.end()   # close the regression test example output file
+                # NOTE: When coupled to a different code, this is where the velocity info
+                # would be passed to the aerodynamic solver
 
+                # Write debug output (positions and velocities) for each timestep.
+                # This is primarily used for regression testing, writing one row
+                # for each timestep + position array entry.
+                debug_output.write(t, self.positions, self.velocities)
 
-# IFW_END: Only need to call ifw_end once.
-#   NOTE:   in the event of an error during the above Init or CalcOutput calls,
-#           the IfW_End routine will be called during that error handling.
-#           This works for IfW, but may not be a desirable way to handle
-#           errors in other codes (we may still want to retrieve some info
-#           from memory before clearing out everything).
-#   NOTE:   Error handling from the ifw_end call may not be entirely necessary,
-#           but we may want to know if some memory was not released properly or
-#           a file not closed correctly.
-ifwlib.ifw_end()
+                # Store the channel outputs requested in the InflowWind input file's OutList section.
+                # In OpenFAST, these would be added to the output channel array for all modules.
+                # Here we store them with the timestamp for writing to file at the end of simulation.
+                all_output_channel_values[i,:] = np.append(t, output_channel_values)
 
+        finally:
+            # Close the debug output file
+            debug_output.end()
 
-#   Now write the ouput channels to a file
-OutFile=inflowwind_library.WriteOutChans(output_file,ifwlib.output_channel_names,ifwlib.output_channel_units)
-OutFile.write(allOutputChannelValues)
-OutFile.end()
+            # Call ifw_end to clean up resources
+            # NOTE: ifw_end is automatically called during error handling of ifw_init and
+            # ifw_calc_output. While this works for InflowWind, other modules might need
+            # to retrieve data from memory before cleanup.
+            self.ifwlib.ifw_end()
 
-print("InflowWind completed.")
+        # Write final outputs
+        out_file = ifw.WriteOutChans(
+            self.config.output_file,
+            self.ifwlib.output_channel_names,
+            self.ifwlib.output_channel_units
+        )
+        out_file.write(all_output_channel_values)
+        out_file.end()
+
+        print("InflowWind completed successfully")
+
+if __name__ == "__main__":
+    driver = InflowWindDriver(InflowWindConfig())
+    driver.run_simulation()

--- a/modules/moordyn/py_md_5MW_OC4Semi/py_md_driver.py
+++ b/modules/moordyn/py_md_5MW_OC4Semi/py_md_driver.py
@@ -1,9 +1,9 @@
-#*******************************************************************************
+#-------------------------------------------------------------------------------
 # LICENSING
-# Copyright (C) 2021 National Renewable Energy Laboratory
-# Author: Nicole Mendoza
+#-------------------------------------------------------------------------------
+# Copyright (C) 2021-present by National Renewable Energy Lab (NREL)
 #
-# This file is part of MoorDyn.
+# This file is part of MoorDyn
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,269 +16,297 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+#-------------------------------------------------------------------------------
+# Overview of MoorDyn python driver
+#-------------------------------------------------------------------------------
+# This script serves as a Python driver for the MoorDyn library. It demonstrates
+# how to interact with the main subroutines of MoorDyn.
 #
-#*******************************************************************************
+# NOTE: This script serves as a template and can be customized to meet
+# individual requirements.
 #
-# This is an exampe of Python driver code for MoorDyn 
+# Basic algorithm for using MoorDyn Python library:
+#   1. Initialize the Python wrapper library:
+#      - Set necessary library values
+#      - Set input file string arrays (from file/script)
 #
-# Usage: This program gives an example for how the user calls the main
-#        subroutines of MoorDyn, and thus is specific to the user
+#   2. Initialize the MoorDyn Fortran library (i.e. C-bindings interface)
+#      - Set initial position, velocity, and acceleration values
+#      - Call moordyn_init once to initialize MoorDyn
+#      - Handle any resulting errors
 #
-# Basic alogrithm for using MoorDyn python library
-#   1.  initialize python wrapper library
-#           set necessary library values
-#           set input file string arrays (from file or script)
-#   2.  initialize MoorDyn Fortran library
-#           set initial position, velocity, acceleration values
-#           call moordyn_init once to initialize
-#           Handle any resulting errors
-#   3.  timestep iteration
-#           set extrapolated values for inputs
-#           call moordyn_updatestates to propogate forwared from t to t+dt
-#           set position, velocity, and acceleration information for all nodes
-#           call moordyn_calcoutput.  Handle any resulting errors
-#           return the resulting force and moment array
-#           aggregate output channnels
-#   4. End
-#         call moordyn_end to close the MoorDyn library and free memory
-#         handle any resulting errors
+#   3. Timestep iteration:
+#      - Set extrapolated values for inputs
+#      - Call moordyn_updatestates to propagate forward from t to t+dt
+#      - Set position, velocity, and acceleration information for all nodes
+#      - Call moordyn_calcoutput. Handle any resulting errors
+#      - Return the resulting force and moment array
+#      - Aggregate output channels
 #
-#
-import numpy as np   
+#   4. End:
+#      - Call moordyn_end to close the MoorDyn library and free memory
+#      - Handle any resulting errors
+
+#-------------------------------------------------------------------------------
+# Imports
+#-------------------------------------------------------------------------------
 import os
 import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
 
-# path to find the moordyn_library.py from the local directory
-os.chdir(sys.path[0])
-mdLibPath=os.path.sep.join(["..", "..", "..", "..", "..", "modules", "moordyn", "python-lib"])
-sys.path.insert(0, mdLibPath)
-print(f"Importing 'moordyn_library' from {mdLibPath}")
-import moordyn_library      # this file handles the conversion from python to c-bound types and should not be changed by the user
+import numpy as np
 
-###############################################################################
-# Locations to build directory relative to r-test directory.  This is specific
-# to the regession testing with openfast and will need to be updated when
-# coupled to other codes or use cases
+#--------------------------------------
+# Library paths
+#--------------------------------------
+# Path to find the driver_utilities.py module from the local directory
+#
+# NOTE: This file contains helper functions to assist with the driver codes
+# across different modules
+modules_path = Path(__file__).parent.joinpath(*[".."]*5, "reg_tests", "r-test", "modules")
+print(f"Importing 'driver_utilities' from {modules_path}")
+sys.path.insert(0, str(modules_path))
+from driver_utilities import *
 
-basename = "libmoordyn_c_binding"
-if sys.platform == "linux" or sys.platform == "linux2":
-    library_path = os.path.sep.join(["..", "..", "..", "..", "..", "build", "modules", "moordyn", basename + ".so"])
-elif sys.platform == "darwin":
-    library_path = os.path.sep.join(["..", "..", "..", "..", "..", "build", "modules", "moordyn", basename + ".dylib"])
-elif sys.platform == "win32":
-    # Windows may have this library installed in one of two locations depending
-    # on which build system was used (CMake or VS).
-    library_path = os.path.sep.join(["..", "..", "..", "..", "..", "build", "modules", "moordyn", basename + ".dll"])   # cmake install location
-    if not os.path.isfile(library_path) and not sys.maxsize > 2**32:        # Try VS build location otherwise
-        library_path = os.path.sep.join(["..", "..", "..", "..", "..", "build", "bin", "MoorDyn_c_binding_Win32.dll"]) # VS build install location
-        if not os.path.isfile(library_path):
-            print(f"Python is 32 bit and cannot find 32 bit MoorDyn_c_binding DLL expected at: {library_path}")
-            exit(1)
-    if not os.path.isfile(library_path) and sys.maxsize > 2**32:        # Try VS build location otherwise
-        library_path = os.path.sep.join(["..", "..", "..", "..", "..", "build", "bin", "MoorDyn_c_binding_x64.dll"]) # VS build install location
-        if not os.path.isfile(library_path):
-            print(f"Python is 64 bit and cannot find 64 bit MoorDyn_c_binding DLL expected at: {library_path}")
-            exit(1)
+# Path to find the moordyn_library.py from the local directory
+os.chdir(Path(__file__).parent)
+md_lib_path = Path(__file__).parent.joinpath(*[".."]*5, "modules", "moordyn", "python-lib")
+sys.path.insert(0, str(md_lib_path))
+print(f"Importing 'moordyn_library' from {md_lib_path}")
+import moordyn_library
 
-# Library path
-try: 
-    # User inserts their own appropriate library path here
-    md_lib = moordyn_library.MoorDynLib(library_path)
-except Exception as e:
-    print("{}".format(e))
-    print(f"MD: Cannot load MoorDyn library at {library_path}")
-    exit(1)
+#-------------------------------------------------------------------------------
+# Configuration classes
+#-------------------------------------------------------------------------------
+@dataclass
+class MoorDynConfig:
+    """Configuration settings for MoorDyn simulation."""
+    num_corrections: int = 0    # Number of correction steps to perform
+    verbose: bool = False       # Enable verbose debug output
 
+    #--------------------------------------
+    # File names
+    #--------------------------------------
+    md_input_file: str = "md_primary.inp"
+    md_output_file: str = "MD.out"
+    md_test_file: str = "5MW_OC4Semi_WSt_WavesWN.out"
+    debug_output_file: str = "MD.dbg"
 
+@dataclass
+class LibraryConfig:
+    """Configuration settings for MoorDyn library."""
+    interpolation_order: int = 2    # Order of interpolation (1: linear -- uses two time steps,
+                                    # 2: quadratic -- uses three time steps)
+    gravity: float = 9.80665        # Gravity (m/s^2)
+    water_density: float = 1025.    # Water density (kg/m^3)
+    water_depth: float = 200.       # Water depth (m), depth is positive
 
-# MD Main input file
-# Can either use this or the input-file-contents-as-string-array - ONE OR THE OTHER, NOT BOTH!
-md_input_file = "md_primary.inp"
+#-------------------------------------------------------------------------------
+# Main driver class
+#-------------------------------------------------------------------------------
+class MoorDynDriver:
+    """Main driver class for MoorDyn simulation."""
 
-# Saving outputs
-#       When coupled to another code, the channels requested in the outlist
-#       section of the output file are passed back for writing to file.  Here
-#       we will write the aggregated output channels to a file at the end of
-#       the simulation.
-md_output_file = "MD.out"
+    def __init__(self, config: MoorDynConfig, lib_config: LibraryConfig):
+        """Initialize the MoorDyn driver."""
+        self.config = config
+        self.lib_config = lib_config
 
-# For debugging only
-verbose = False # User can set this to false for routine operations
-if verbose:
-    dbgFileName = "MD.dbg"
-    dbg_outfile = moordyn_library.DriverDbg(dbgFileName)
+        # Load test data and set time parameters
+        self.test_data = self._load_test_data()
+        self.time = self.test_data[:, 0]
+        self.dt = self.time[1] - self.time[0]
 
-# Test file
-# Note this only contains channels for platform motions
-#       B1Surge B1Sway B1Heave B1Roll B1Pitch B1Yaw 
-#       B1TVxi B1TVyi B1TVzi B1RVxi B1RVyi B1RVzi
-#       B1TAxi B1TAyi B1TAzi B1RAxi B1RAyi B1RAzi)
-md_test_file = "5MW_OC4Semi_WSt_WavesWN.out"
+        # Initialize library
+        self.mdlib = self._initialize_library()
 
-#=============================================================================================================================
-#-------------------------------------------------------- SET INPUTS ---------------------------------------------------------
-#=============================================================================================================================
+        # Initialize debug output if needed
+        self.debug_output = None
+        if self.config.verbose:
+            self.debug_output = moordyn_library.DriverDbg(self.config.debug_output_file)
 
-# Main input file - MoorDyn V2
-# Usage: the contents of this string follow the identical syntax to what is described for the MoorDyn input file in the user guides and documentation
-# Please modify the string contents based on your specific use case
-md_input_string_array = []
+    def _load_test_data(self) -> np.ndarray:
+        """Load test data from file."""
+        try:
+            with open(self.config.md_test_file, "r") as ft:
+                lines = ft.read().splitlines()[8:-1]  # Skip header rows and last line
+                data = np.array([list(map(float, line.split())) for line in lines])
+                return data
 
-#   Main MoorDyn input file
-#       This file is read from disk to an array of strings with the line
-#       endings stripped off.  This array will have the same number of elements
-#       as there are lines in the file.
-# The input file will only be loaded once
-try:
-    fh = open(md_input_file, "r")
-except Exception as e:
-    print("{}".format(e))
-    print(f"Cannot load MoorDyn input file")
-    exit(1)
-
-for line in fh:
-  # strip line ending and ending white space and add to array of strings
-  md_input_string_array.append(line.rstrip())
-fh.close()
-
-# Test file for MoorDyn time-accurate inputs from OC4 Semi Test Case
-try:
-    ft = open(md_test_file, "r")
-    tmp = ft.read().splitlines() # each line in file is a row in tmp
-    tmp2 = tmp[8:-1] # skip the header rows - get the raw data only
-    data = np.empty([len(tmp2),96])
-    time = np.empty(len(tmp2))
-    for d in range(0,len(tmp2)):
-        tmp3 = tmp2[d].split() # split the row into columns
-        for k in range(0,len(tmp3)):
-            data[d,k] = float(tmp3[k]) # for each column, convert the string into a float
-        time[d] = data[d,0]
-    ft.close()
-except Exception as e:
-    print("{}".format(e))
-    print(f"Cannot load MoorDyn test file")
-    exit(1)
-
-
-#==============================================================================
-# Basic alogrithm for using the MoorDyn library
-
-# Time inputs
-t_start             = time[0]            # initial or start time. MUST BE >= 0
-md_lib.dt           = time[1] - time[0]  # time interval
-md_lib.total_time   = time[-1]           # total or end time
-# time                = np.arange(t_start,md_lib.total_time + md_lib.dt,md_lib.dt)
-md_lib.numTimeSteps = len(time)
-
-# System inputs
-g                   = 9.80665            # gravitational acceleration (m/s^2). usage: g is positive
-rho_h2o             = 1025               # water density (kg/m^3)
-d_h2o               = 200                # water depth (m). usage: depth is positive
-platform_init_pos   = np.array([data[0, 1], data[0, 2], data[0, 3], data[0, 4], data[0, 5], data[0, 6]]) # platform/hull/substructure initial position [x, y, z, Rx, Ry, Rz] in openFAST global coordinates [m, m, m, rad, rad, rad]
-platform_init_vel   = np.array([data[0, 7], data[0, 8], data[0, 9], data[0,10], data[0,11], data[0,12]]) # platform/hull/substructure initial velocities [x,y,z,Rx,Ry,Rz]_dot  -- first deriv (velocities)
-platform_init_acc   = np.array([data[0,13], data[0,14], data[0,15], data[0,16], data[0,17], data[0,18]]) # platform/hull/substructure initial accelerations [x,y,z,Rx,Ry,Rz]_ddot -- second deriv (accelerations)
-forces              = np.array([data[0,0], data[0,0], data[0,0], data[0,0], data[0,0], data[0,0]]) # platform/hull/substructure forces (output) [Fx,Fy,Fz,Mx,My,Mz]   -- resultant forces/moments at each node
-
-# Interpolation Order - MUST BE 1: linear (uses two time steps) or 2: quadratic (uses three time steps)
-InterpOrder         = 2
-
-# PREDICTOR-CORRECTOR: For checking if our library is correctly handling correction steps, set this to > 0
-NumCorrections      = 0 # SET TO 0 IF NOT DOING CORRECTION STEP
-
-#=============================================================================================================================
-#-------------------------------------------------------- RUN MOORDYN --------------------------------------------------------
-#=============================================================================================================================
-
-# MD_INIT: Only need to call md_init once
-# ----------------------------------------------------------------------------------------------------------------------------
-try:
-    md_lib.md_init(md_input_string_array, g, rho_h2o, d_h2o, platform_init_pos, InterpOrder)
-except Exception as e:
-    print("{}".format(e))   # Exceptions handled in moordyn_library.py
-    if verbose:
-        #dbg_outfile.write("MD driver: MD init call failed")
-        dbg_outfile.end()
-    exit(1)
-
-# Set up the output channels listed in the MD input file
-output_channel_names = md_lib._channel_names.value
-output_channel_units = md_lib._channel_units.value
-output_channel_values = np.zeros(md_lib._numChannels.value)
-output_channel_array  = np.zeros( (md_lib.numTimeSteps,md_lib._numChannels.value+1) ) # includes time
-
-# MD_calcOutput: calculates outputs for initial time t=0 and initial position & velocity
-# ----------------------------------------------------------------------------------------------------------------------------
-try: 
-    md_lib.md_calcOutput(time[0], platform_init_pos, platform_init_vel, platform_init_acc, forces, output_channel_values)
-except Exception as e:
-    print("{}".format(e))   # Exceptions handled in moordyn_library.py
-    if verbose:
-        #dbg_outfile.write("MD driver: MD initial calcOutput call failed")
-        dbg_outfile.end()
-    exit(1)
-
-# Write the outputs at t = t_initial
-output_channel_array[0,:] = np.append(time[0],output_channel_values)
-if verbose:
-    dbg_outfile.write(time[0],platform_init_pos,platform_init_vel,platform_init_acc,forces)
-
-# Run MD at each time step
-# ----------------------------------------------------------------------------------------------------------------------------
-for i in range( 0, len(time)-1):
-
-    # Current t = time[i]
-
-    # print time every simulation second
-    if (i % round(1.0/md_lib.dt))==0:
-        print(f"Time: {time[i]}")
-
-    # IF DOING PREDICTOR-CORRECTOR
-    for correction in range(0, NumCorrections+1):
-
-        # User must update position, velocities, and accelerations at each time step
-        # Note: MD currently handles one interface point, i.e. substructure is represented as a single point
-        Positions     = [data[i, 1], data[i, 2], data[i, 3], data[i, 4], data[i, 5], data[i, 6]]
-        Velocities    = [data[i, 7], data[i, 8], data[i, 9], data[i,10], data[i,11], data[i,12]]
-        Accelerations = [data[i,13], data[i,14], data[i,15], data[i,16], data[i,17], data[i,18]]
-
-        # Call md_updateStates - propagate the arrays
-        try: 
-            md_lib.md_updateStates(time[i], time[i+1], Positions, Velocities, Accelerations) # positions, velocities, and accelerations are all at current time
         except Exception as e:
-            print("{}".format(e))   # Exceptions handled in moordyn_library.py
-            if verbose:
-                #dbg_outfile.write("MoorDyn_Driver.py: MD_updateStates call failed")
-                dbg_outfile.end()
-            exit(1)
+            print(f"Cannot load MoorDyn test file: {e}")
+            sys.exit(1)
 
-        # Call md_calcOutput: calculate outputs for the current time step @ t+dt
-        try: 
-            md_lib.md_calcOutput(time[i+1], Positions, Velocities, Accelerations, forces, output_channel_values) # output channel values are overwritten for each time step
+    def _initialize_library(self) -> moordyn_library.MoorDynLib:
+        """Initialize the MoorDyn library."""
+        try:
+            mdlib = moordyn_library.MoorDynLib(get_library_path(module_name="moordyn"))
         except Exception as e:
-            print("{}".format(e))   # Exceptions handled in moordyn_library.py
-            if verbose:
-                #dbg_outfile.write("MoorDyn_Driver.py: MD_calcOutput call failed")
-                dbg_outfile.end()
-            exit(1)
-        
-        # Clean up before moving on to next time step
-        output_channel_array[i+1,:] = np.append(time[i+1],output_channel_values)
-        if verbose:
-            dbg_outfile.write(time[i+1],Positions,Velocities,Accelerations,forces)
+            print(f"Cannot load MoorDyn library: {e}")
+            sys.exit(1)
 
-# MD_END: Only need to call md_end once when you're done
-# ----------------------------------------------------------------------------------------------------------------------------
-try:
-    md_lib.md_end()
-except Exception as e:
-    print("{}".format(e))   # Exceptions handled in moordyn_library.py
-    if verbose:
-        #dbg_outfile.write("MoorDyn_Driver.py: MD_end call failed")
-        dbg_outfile.end()
-    exit(1)
+        # Set library parameters
+        mdlib.dt = self.dt # time interval
+        mdlib.total_time = self.time[-1] # total or end time
+        mdlib.numTimeSteps = len(self.time) # number of time steps
 
-# Finally, write the ouput channel values to a file
-OutFile=moordyn_library.WriteOutChans(md_output_file,md_lib.output_channel_names,md_lib.output_channel_units)
-OutFile.write(output_channel_array)
-OutFile.end()
-exit()
+        # Load and process input file
+        md_input_string_array = read_lines_from_file(self.config.md_input_file)
+
+        # Extract initial conditions from test data
+        #
+        # Initial position of platform/hull/substructure in OpenFAST global coordinates
+        # Format: [x, y, z, Rx, Ry, Rz] where units are [m, m, m, rad, rad, rad]
+        self.platform_init_pos = self.test_data[0, 1:7]
+        # Initial velocities of platform/hull/substructure
+        # Format: [x_dot, y_dot, z_dot, Rx_dot, Ry_dot, Rz_dot] where
+        # _dot denotes first derivatives (velocities)
+        self.platform_init_vel = self.test_data[0, 7:13]
+        # Initial accelerations of platform/hull/substructure
+        # Format: [x_ddot, y_ddot, z_ddot, Rx_ddot, Ry_ddot, Rz_ddot] where
+        # _ddot denotes second derivatives (accelerations)
+        self.platform_init_acc = self.test_data[0, 13:19]
+
+        # Initialize MoorDyn
+        try:
+            mdlib.md_init(
+                md_input_string_array,
+                self.lib_config.gravity,
+                self.lib_config.water_density,
+                self.lib_config.water_depth,
+                self.platform_init_pos,
+                self.lib_config.interpolation_order
+            )
+        except Exception as e:
+            print(f"MoorDyn initialization failed: {e}")
+            sys.exit(1)
+
+        # Set up the output channels listed in the MD input file
+        self.output_channel_names = mdlib._channel_names.value
+        print("output_channel_names: ", self.output_channel_names)
+        self.output_channel_units = mdlib._channel_units.value
+        print("output_channel_units: ", self.output_channel_units)
+        self.output_channel_values = np.zeros(mdlib._numChannels.value)
+        self.output_channel_array = np.zeros((mdlib.numTimeSteps, mdlib._numChannels.value + 1)) # includes time
+
+        return mdlib
+
+    def run_simulation(self) -> None:
+        """Run the main simulation loop."""
+        # Initialize arrays for outputs
+        forces = np.zeros(6)
+
+        try:
+            # Process initial timestep
+            self._process_timestep(
+                0,
+                self.time[0],
+                self.platform_init_pos,   # positions
+                self.platform_init_vel,   # velocities
+                self.platform_init_acc,   # accelerations
+                forces,
+                update_states=False,
+                previous_time=None
+            )
+
+            # Time stepping loop
+            for i in range(len(self.time) - 1):
+                # Print progress
+                if (i % round(1.0/self.dt)) == 0:
+                    print(f"Time: {self.time[i]}")
+
+                # Get current state from test data
+                positions = self.test_data[i + 1, 1:7]
+                velocities = self.test_data[i + 1, 7:13]
+                accelerations = self.test_data[i + 1, 13:19]
+
+                # Correction loop
+                for _ in range(self.config.num_corrections + 1):
+                    self._process_timestep(
+                        i + 1,
+                        self.time[i + 1],
+                        positions,
+                        velocities,
+                        accelerations,
+                        forces,
+                        update_states=True,
+                        previous_time=self.time[i]
+                    )
+
+        finally:
+            # End MoorDyn simulation
+            try:
+                self.mdlib.md_end()
+            except Exception as e:
+                print(f"Failed to end MoorDyn simulation: {e}")
+                sys.exit(1)
+
+            if self.debug_output:
+                self.debug_output.end()
+
+        # Write output channels to file
+        channel_names = self.output_channel_names.decode().split()
+        channel_units = self.output_channel_units.decode().split()
+        print("channel_names: ", channel_names)
+        print("channel_units: ", channel_units)
+        out_file = moordyn_library.WriteOutChans(
+            self.config.md_output_file,
+            channel_names,
+            channel_units
+        )
+        out_file.write(self.output_channel_array)
+        out_file.end()
+
+    def _process_timestep(
+        self,
+        i_timestep: int,
+        current_time: float,
+        positions: np.ndarray,
+        velocities: np.ndarray,
+        accelerations: np.ndarray,
+        forces: np.ndarray,
+        update_states: bool = False,
+        previous_time: Optional[float] = None
+    ) -> None:
+        """Process a single timestep in the simulation."""
+        # Update states if requested
+        if update_states:
+            try:
+                self.mdlib.md_updateStates(
+                    previous_time,
+                    current_time,
+                    positions,
+                    velocities,
+                    accelerations
+                )
+            except Exception as e:
+                print(f"Failed to update states at T={current_time}: {e}")
+                raise
+
+        # Calculate outputs
+        try:
+            self.mdlib.md_calcOutput(
+                current_time,
+                positions,
+                velocities,
+                accelerations,
+                forces,
+                self.output_channel_values
+            )
+        except Exception as e:
+            print(f"Failed to calculate outputs at T={current_time}: {e}")
+            raise
+
+        # Store outputs
+        self.output_channel_array[i_timestep, :] = np.append(current_time, self.output_channel_values)
+
+        # Write debug output if enabled
+        if self.config.verbose:
+            self.debug_output.write(current_time, positions, velocities, accelerations, forces)
+
+if __name__ == "__main__":
+    driver = MoorDynDriver(MoorDynConfig(), LibraryConfig())
+    driver.run_simulation()

--- a/modules/visread.py
+++ b/modules/visread.py
@@ -1,0 +1,97 @@
+import numpy as np
+import vtk
+
+def visread_positions_ref(filename):
+    reader = vtk.vtkXMLPolyDataReader()
+
+    reader.SetFileName(filename)
+    reader.Update()
+
+    _arName = []
+    _numArrays = reader.GetNumberOfPointArrays()
+    for i in range(_numArrays):
+        _arName.append(reader.GetPointArrayName(i))
+
+    position_ar = np.array( reader.GetOutput().GetPoints().GetData(),  dtype="float32")
+    _orientX = np.array( reader.GetOutput().GetPointData().GetArray(_arName.index('RefOrientationX')),dtype="float64")
+    _orientY = np.array( reader.GetOutput().GetPointData().GetArray(_arName.index('RefOrientationY')),dtype="float64")
+    _orientZ = np.array( reader.GetOutput().GetPointData().GetArray(_arName.index('RefOrientationZ')),dtype="float64")
+
+    orient_ar = np.hstack((_orientX, _orientY, _orientZ))
+
+    numpts_pos = np.size(position_ar,0)
+    numpts_ori = np.size(orient_ar,0)
+
+    if numpts_pos != numpts_ori:
+        raise Exception("\nvisread_positions: Number of position and orientation points differ in file "+filename)
+
+    return position_ar, orient_ar, numpts_pos
+
+
+def visread_positions(filename):
+    reader = vtk.vtkXMLPolyDataReader()
+
+    reader.SetFileName(filename)
+    reader.Update()
+
+    _arName = []
+    _numArrays = reader.GetNumberOfPointArrays()
+    for i in range(_numArrays):
+        _arName.append(reader.GetPointArrayName(i))
+
+    position_ar = np.array( reader.GetOutput().GetPoints().GetData(),  dtype="float32")
+    _orientX = np.array( reader.GetOutput().GetPointData().GetArray(_arName.index('OrientationX')),dtype="float64")
+    _orientY = np.array( reader.GetOutput().GetPointData().GetArray(_arName.index('OrientationY')),dtype="float64")
+    _orientZ = np.array( reader.GetOutput().GetPointData().GetArray(_arName.index('OrientationZ')),dtype="float64")
+
+    orient_ar = np.hstack((_orientX, _orientY, _orientZ))
+
+    numpts_pos = np.size(position_ar,0)
+    numpts_ori = np.size(orient_ar,0)
+
+    if numpts_pos != numpts_ori:
+        raise Exception("\nvisread_positions: Number of position and orientation points differ in file "+filename)
+
+    return position_ar, orient_ar, numpts_pos
+
+
+def visread_velacc(filename,numpts):
+    reader = vtk.vtkXMLPolyDataReader()
+
+    reader.SetFileName(filename)
+    reader.Update()
+
+    _arName = []
+    _numArrays = reader.GetNumberOfPointArrays()
+    for i in range(_numArrays):
+        _arName.append(reader.GetPointArrayName(i))
+
+    if 'TranslationalVelocity' in _arName:
+        _TV = np.array( reader.GetOutput().GetPointData().GetArray(_arName.index('TranslationalVelocity')),dtype="float32")
+        if np.size(_TV,0) != numpts:
+            raise Exception("\nvisread_velacc: Unexpected number of translational velocity points in file"+filename+" (expected "+str(numpts)+", got "+str(np.size(_TV,0))+")")
+    else:
+        _TV = np.zeros((numpts,3),dtype="float32")
+    if 'RotationalVelocity' in _arName:
+        _RV = np.array( reader.GetOutput().GetPointData().GetArray(_arName.index('RotationalVelocity'   )),dtype="float32")
+        if np.size(_RV,0) != numpts:
+            raise Exception("\nvisread_velacc: Unexpected number of rotational velocity points in file"+filename+" (expected "+str(numpts)+", got "+str(np.size(_RV,0))+")")
+    else:
+        _RV = np.zeros((numpts,3),dtype="float32")
+    vel_ar = np.hstack((_TV, _RV))
+
+    if 'TranslationalAcceleration' in _arName:
+        _TA = np.array( reader.GetOutput().GetPointData().GetArray(_arName.index('TranslationalAcceleration')),dtype="float32")
+        if np.size(_TA,0) != numpts:
+            raise Exception("\nvisread_velacc: Unexpected number of translational acceleration points in file"+filename+" (expected "+str(numpts)+", got "+str(np.size(_TA,0))+")")
+    else:
+        _TA = np.zeros((numpts,3),dtype="float32")
+    if 'RotationalAcceleration' in _arName:
+        _RA = np.array( reader.GetOutput().GetPointData().GetArray(_arName.index('RotationalAcceleration'   )),dtype="float32")
+        if np.size(_RA,0) != numpts:
+            raise Exception("\nvisread_velacc: Unexpected number of rotational acceleration points in file"+filename+" (expected "+str(numpts)+", got "+str(np.size(_RA,0))+")")
+    else:
+        _RA = np.zeros((numpts,3),dtype="float32")
+    acc_ar = np.hstack((_TA, _RA))
+
+    return vel_ar, acc_ar


### PR DESCRIPTION
Major refactor of the driver codes for Python-based libraries to the C-bindings interfaces. These driver codes are essentially regression tests for several modules of OpenFAST. Following tests were refactored in this work

```
Test project /Users/fbhuiyan/dev/fb-openfast/build
    Start  81: py_ad_5MW_OC4Semi_WSt_WavesWN
1/5 Test  #81: py_ad_5MW_OC4Semi_WSt_WavesWN ....   Passed    1.04 sec
    Start  82: py_ad_B1n2_OLAF
2/5 Test  #82: py_ad_B1n2_OLAF ..................   Passed    1.06 sec
    Start 114: py_hd_5MW_OC4Semi_WSt_WavesWN
3/5 Test #114: py_hd_5MW_OC4Semi_WSt_WavesWN ....   Passed    6.25 sec
    Start 134: py_ifw_turbsimff
4/5 Test #134: py_ifw_turbsimff .................   Passed    0.32 sec
    Start 155: py_md_5MW_OC4Semi
5/5 Test #155: py_md_5MW_OC4Semi ................   Passed    2.10 sec
```