### PR TITLE
ServoDyn-StC r-test: Updated comment StC_SA_MODE

### DIFF
--- a/glue-codes/openfast/5MW_Baseline/NRELOffshrBsline5MW_ServoDyn_StC.dat
+++ b/glue-codes/openfast/5MW_Baseline/NRELOffshrBsline5MW_ServoDyn_StC.dat
@@ -66,7 +66,7 @@ False         Use_F_TBL    - Use spring force from user-defined table (flag)
 ---------------------- StructCtrl CONTROL -------------------------------------------- [used only when StC_DOF_MODE=1, 2, 3 or 7]
           0   StC_CMODE     - Control mode (switch) {0:none; 1: Semi-Active Control Mode; 3: Active Control Mode through user subroutine; 4: Active Control Mode through Simulink (not available); 5: Active Control Mode through Bladed interface}
           0   StC_CChan     - Control channel group (1:10) for stiffness and damping (StC_[XYZ]_K, StC_[XYZ]_C, and StC_[XYZ]_Brake) (specify additional channels for blade instances of StC active control -- one channel per blade) [used only when StC_DOF_MODE=1, 2, 3, or 7 and StC_CMODE=4 or 5]
-          1   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} (-)
+          1   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} [used only when StC_CMODE=1]
           0   StC_X_C_HIGH  - StC X high damping for ground hook control
           0   StC_X_C_LOW   - StC X low damping for ground hook control
           0   StC_Y_C_HIGH  - StC Y high damping for ground hook control

--- a/glue-codes/openfast/5MW_Land_BD_DLL_WTurb_StC/StC-Bld-PrescribedForce.dat
+++ b/glue-codes/openfast/5MW_Land_BD_DLL_WTurb_StC/StC-Bld-PrescribedForce.dat
@@ -66,7 +66,7 @@ False         Use_F_TBL    - Use spring force from user-defined table (flag)
 ---------------------- StructCtrl CONTROL -------------------------------------------- [used only when StC_DOF_MODE=1, 2, 3 or 7]
           0   StC_CMODE     - Control mode (switch) {0:none; 1: Semi-Active Control Mode; 3: Active Control Mode through user subroutine; 4: Active Control Mode through Simulink (not available); 5: Active Control Mode through Bladed interface}
           0   StC_CChan     - Control channel group (1:10) for stiffness and damping (StC_[XYZ]_K, StC_[XYZ]_C, and StC_[XYZ]_Brake) (specify additional channels for blade instances of StC active control -- one channel per blade) [used only when StC_DOF_MODE=1, 2, 3, or 7 and StC_CMODE=4 or 5]
-          1   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} (-)
+          1   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} [used only when StC_CMODE=1]
           0   StC_X_C_HIGH  - StC X high damping for ground hook control
           0   StC_X_C_LOW   - StC X low damping for ground hook control
           0   StC_Y_C_HIGH  - StC Y high damping for ground hook control

--- a/glue-codes/openfast/AOC_YFriction_Loading/AOC_YFriction_Loading_StC.dat
+++ b/glue-codes/openfast/AOC_YFriction_Loading/AOC_YFriction_Loading_StC.dat
@@ -49,7 +49,7 @@ False         Use_F_TBL    - Use spring force from user-defined table (flag)
 ---------------------- StructCtrl CONTROL -------------------------------------------- [used only when StC_DOF_MODE=1, 2, 3, or 7]
           0   StC_CMODE     - Control mode (switch) {0:none; 1: Semi-Active Control Mode; 3: Active Control Mode through user subroutine; 4: Active Control Mode through Simulink (not available); 5: Active Control Mode through Bladed interface}
           0   StC_CChan     - Control channel group (1:10) for stiffness and damping (StC_[XYZ]_K, StC_[XYZ]_C, and StC_[XYZ]_Brake) [used only when StC_DOF_MODE=1, 2, 3, or 7 and StC_CMODE=4 or 5]
-          1   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} (-)
+          1   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} [used only when StC_CMODE=1]
           0   StC_X_C_HIGH  - StC X high damping for ground hook control
           0   StC_X_C_LOW   - StC X low damping for ground hook control
           0   StC_Y_C_HIGH  - StC Y high damping for ground hook control

--- a/glue-codes/openfast/IEA22MW_ModalDamping/StC-Bld-PrescribedForce.dat
+++ b/glue-codes/openfast/IEA22MW_ModalDamping/StC-Bld-PrescribedForce.dat
@@ -49,7 +49,7 @@ False         Use_F_TBL    - Use spring force from user-defined table (flag)
 ---------------------- StructCtrl CONTROL -------------------------------------------- [used only when StC_DOF_MODE=1, 2, 3, or 7]
           0   StC_CMODE     - Control mode (switch) {0:none; 1: Semi-Active Control Mode; 3: Active Control Mode through user subroutine; 4: Active Control Mode through Simulink (not available); 5: Active Control Mode through Bladed interface}
           0   StC_CChan     - Control channel group (1:10) for stiffness and damping (StC_[XYZ]_K, StC_[XYZ]_C, and StC_[XYZ]_Brake) (specify additional channels for blade instances of StC active control -- one channel per blade) [used only when StC_DOF_MODE=1, 2, 3, or 7 and StC_CMODE=4 or 5]
-          3   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} (-)
+          3   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} [used only when StC_CMODE=1]
           0   StC_X_C_HIGH  - StC X high damping for ground hook control
           0   StC_X_C_LOW   - StC X low damping for ground hook control
           0   StC_Y_C_HIGH  - StC Y high damping for ground hook control

--- a/glue-codes/openfast/IEA22MW_ModalDampingLoose/StC-Bld-PrescribedForce.dat
+++ b/glue-codes/openfast/IEA22MW_ModalDampingLoose/StC-Bld-PrescribedForce.dat
@@ -49,7 +49,7 @@ False         Use_F_TBL    - Use spring force from user-defined table (flag)
 ---------------------- StructCtrl CONTROL -------------------------------------------- [used only when StC_DOF_MODE=1, 2, 3, or 7]
           0   StC_CMODE     - Control mode (switch) {0:none; 1: Semi-Active Control Mode; 3: Active Control Mode through user subroutine; 4: Active Control Mode through Simulink (not available); 5: Active Control Mode through Bladed interface}
           0   StC_CChan     - Control channel group (1:10) for stiffness and damping (StC_[XYZ]_K, StC_[XYZ]_C, and StC_[XYZ]_Brake) (specify additional channels for blade instances of StC active control -- one channel per blade) [used only when StC_DOF_MODE=1, 2, 3, or 7 and StC_CMODE=4 or 5]
-          3   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} (-)
+          3   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} [used only when StC_CMODE=1]
           0   StC_X_C_HIGH  - StC X high damping for ground hook control
           0   StC_X_C_LOW   - StC X low damping for ground hook control
           0   StC_Y_C_HIGH  - StC Y high damping for ground hook control

--- a/glue-codes/openfast/StC_test_OC4Semi/StC-Bld-PrescribedForce.dat
+++ b/glue-codes/openfast/StC_test_OC4Semi/StC-Bld-PrescribedForce.dat
@@ -66,7 +66,7 @@ False         Use_F_TBL    - Use spring force from user-defined table (flag)
 ---------------------- StructCtrl CONTROL -------------------------------------------- [used only when StC_DOF_MODE=1, 2, 3, or 7]
           0   StC_CMODE     - Control mode (switch) {0:none; 1: Semi-Active Control Mode; 3: Active Control Mode through user subroutine; 4: Active Control Mode through Simulink (not available); 5: Active Control Mode through Bladed interface}
           0   StC_CChan     - Control channel group (1:10) for stiffness and damping (StC_[XYZ]_K, StC_[XYZ]_C, and StC_[XYZ]_Brake) (specify additional channels for blade instances of StC active control -- one channel per blade) [used only when StC_DOF_MODE=1, 2, 3, or 7 and StC_CMODE=4 or 5]
-          1   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} (-)
+          1   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} [used only when StC_CMODE=1]
           0   StC_X_C_HIGH  - StC X high damping for ground hook control
           0   StC_X_C_LOW   - StC X low damping for ground hook control
           0   StC_Y_C_HIGH  - StC Y high damping for ground hook control

--- a/glue-codes/openfast/StC_test_OC4Semi/StC-Nac-Omni.dat
+++ b/glue-codes/openfast/StC_test_OC4Semi/StC-Nac-Omni.dat
@@ -66,7 +66,7 @@ False         Use_F_TBL    - Use spring force from user-defined table (flag)
 ---------------------- StructCtrl CONTROL -------------------------------------------- [used only when StC_DOF_MODE=1, 2, 3, or 7]
           0   StC_CMODE     - Control mode (switch) {0:none; 1: Semi-Active Control Mode; 3: Active Control Mode through user subroutine; 4: Active Control Mode through Simulink (not available); 5: Active Control Mode through Bladed interface}
           0   StC_CChan     - Control channel group (1:10) for stiffness and damping (StC_[XYZ]_K, StC_[XYZ]_C, and StC_[XYZ]_Brake) (specify additional channels for blade instances of StC active control -- one channel per blade) [used only when StC_DOF_MODE=1, 2, 3, or 7 and StC_CMODE=4 or 5]
-          1   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} (-)
+          1   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} [used only when StC_CMODE=1]
           0   StC_X_C_HIGH  - StC X high damping for ground hook control
           0   StC_X_C_LOW   - StC X low damping for ground hook control
           0   StC_Y_C_HIGH  - StC Y high damping for ground hook control

--- a/glue-codes/openfast/StC_test_OC4Semi/StC-Sub-Zdof-1.dat
+++ b/glue-codes/openfast/StC_test_OC4Semi/StC-Sub-Zdof-1.dat
@@ -66,7 +66,7 @@ False         Use_F_TBL    - Use spring force from user-defined table (flag)
 ---------------------- StructCtrl CONTROL -------------------------------------------- [used only when StC_DOF_MODE=1, 2, 3, or 7]
           0   StC_CMODE     - Control mode (switch) {0:none; 1: Semi-Active Control Mode; 3: Active Control Mode through user subroutine; 4: Active Control Mode through Simulink (not available); 5: Active Control Mode through Bladed interface}
           0   StC_CChan     - Control channel group (1:10) for stiffness and damping (StC_[XYZ]_K, StC_[XYZ]_C, and StC_[XYZ]_Brake) (specify additional channels for blade instances of StC active control -- one channel per blade) [used only when StC_DOF_MODE=1, 2, 3, or 7 and StC_CMODE=4 or 5]
-          1   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} (-)
+          1   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} [used only when StC_CMODE=1]
           0   StC_X_C_HIGH  - StC X high damping for ground hook control
           0   StC_X_C_LOW   - StC X low damping for ground hook control
           0   StC_Y_C_HIGH  - StC Y high damping for ground hook control

--- a/glue-codes/openfast/StC_test_OC4Semi/StC-Sub-Zdof-2.dat
+++ b/glue-codes/openfast/StC_test_OC4Semi/StC-Sub-Zdof-2.dat
@@ -66,7 +66,7 @@ False         Use_F_TBL    - Use spring force from user-defined table (flag)
 ---------------------- StructCtrl CONTROL -------------------------------------------- [used only when StC_DOF_MODE=1, 2, 3, or 7]
           0   StC_CMODE     - Control mode (switch) {0:none; 1: Semi-Active Control Mode; 3: Active Control Mode through user subroutine; 4: Active Control Mode through Simulink (not available); 5: Active Control Mode through Bladed interface}
           0   StC_CChan     - Control channel group (1:10) for stiffness and damping (StC_[XYZ]_K, StC_[XYZ]_C, and StC_[XYZ]_Brake) (specify additional channels for blade instances of StC active control -- one channel per blade) [used only when StC_DOF_MODE=1, 2, 3, or 7 and StC_CMODE=4 or 5]
-          1   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} (-)
+          1   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} [used only when StC_CMODE=1]
           0   StC_X_C_HIGH  - StC X high damping for ground hook control
           0   StC_X_C_LOW   - StC X low damping for ground hook control
           0   StC_Y_C_HIGH  - StC Y high damping for ground hook control

--- a/glue-codes/openfast/StC_test_OC4Semi/StC-Twr-TLCD.dat
+++ b/glue-codes/openfast/StC_test_OC4Semi/StC-Twr-TLCD.dat
@@ -66,7 +66,7 @@ False         Use_F_TBL    - Use spring force from user-defined table (flag)
 ---------------------- StructCtrl CONTROL -------------------------------------------- [used only when StC_DOF_MODE=1, 2, 3, or 7]
           0   StC_CMODE     - Control mode (switch) {0:none; 1: Semi-Active Control Mode; 3: Active Control Mode through user subroutine; 4: Active Control Mode through Simulink (not available); 5: Active Control Mode through Bladed interface}
           0   StC_CChan     - Control channel group (1:10) for stiffness and damping (StC_[XYZ]_K, StC_[XYZ]_C, and StC_[XYZ]_Brake) (specify additional channels for blade instances of StC active control -- one channel per blade) [used only when StC_DOF_MODE=1, 2, 3, or 7 and StC_CMODE=4 or 5]
-          1   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} (-)
+          1   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} [used only when StC_CMODE=1]
           0   StC_X_C_HIGH  - StC X high damping for ground hook control
           0   StC_X_C_LOW   - StC X low damping for ground hook control
           0   StC_Y_C_HIGH  - StC Y high damping for ground hook control

--- a/glue-codes/openfast/StC_test_OC4Semi_Linear_Nac/StC-Nac-XDir.dat
+++ b/glue-codes/openfast/StC_test_OC4Semi_Linear_Nac/StC-Nac-XDir.dat
@@ -66,7 +66,7 @@ False         Use_F_TBL    - Use spring force from user-defined table (flag)
 ---------------------- StructCtrl CONTROL -------------------------------------------- [used only when StC_DOF_MODE=1, 2, 3, or 7]
           0   StC_CMODE     - Control mode (switch) {0:none; 1: Semi-Active Control Mode; 3: Active Control Mode through user subroutine; 4: Active Control Mode through Simulink (not available); 5: Active Control Mode through Bladed interface}
           4   StC_CChan     - Control channel group (1:10) for stiffness and damping (StC_[XYZ]_K, StC_[XYZ]_C, and StC_[XYZ]_Brake) (specify additional channels for blade instances of StC active control -- one channel per blade) [used only when StC_DOF_MODE=1, 2, 3, or 7 and StC_CMODE=4 or 5]
-          1   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} (-)
+          1   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} [used only when StC_CMODE=1]
           0   StC_X_C_HIGH  - StC X high damping for ground hook control
           0   StC_X_C_LOW   - StC X low damping for ground hook control
           0   StC_Y_C_HIGH  - StC Y high damping for ground hook control

--- a/glue-codes/openfast/StC_test_OC4Semi_Linear_Tow/StC-Tow-XDir.dat
+++ b/glue-codes/openfast/StC_test_OC4Semi_Linear_Tow/StC-Tow-XDir.dat
@@ -66,7 +66,7 @@ False         Use_F_TBL    - Use spring force from user-defined table (flag)
 ---------------------- StructCtrl CONTROL -------------------------------------------- [used only when StC_DOF_MODE=1, 2, 3, or 7]
           0   StC_CMODE     - Control mode (switch) {0:none; 1: Semi-Active Control Mode; 3: Active Control Mode through user subroutine; 4: Active Control Mode through Simulink (not available); 5: Active Control Mode through Bladed interface}
           4   StC_CChan     - Control channel group (1:10) for stiffness and damping (StC_[XYZ]_K, StC_[XYZ]_C, and StC_[XYZ]_Brake) (specify additional channels for blade instances of StC active control -- one channel per blade) [used only when StC_DOF_MODE=1, 2, 3, or 7 and StC_CMODE=4 or 5]
-          1   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} (-)
+          1   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} [used only when StC_CMODE=1]
           0   StC_X_C_HIGH  - StC X high damping for ground hook control
           0   StC_X_C_LOW   - StC X low damping for ground hook control
           0   StC_Y_C_HIGH  - StC Y high damping for ground hook control

--- a/glue-codes/openfast/StC_test_OC4Semi_blade2/StC-Bld2-PrescribedForce.dat
+++ b/glue-codes/openfast/StC_test_OC4Semi_blade2/StC-Bld2-PrescribedForce.dat
@@ -66,7 +66,7 @@ False         Use_F_TBL    - Use spring force from user-defined table (flag)
 ---------------------- StructCtrl CONTROL -------------------------------------------- [used only when StC_DOF_MODE=1, 2, 3, or 7]
           0   StC_CMODE     - Control mode (switch) {0:none; 1: Semi-Active Control Mode; 3: Active Control Mode through user subroutine; 4: Active Control Mode through Simulink (not available); 5: Active Control Mode through Bladed interface}
           0   StC_CChan     - Control channel group (1:10) for stiffness and damping (StC_[XYZ]_K, StC_[XYZ]_C, and StC_[XYZ]_Brake) (specify additional channels for blade instances of StC active control -- one channel per blade) [used only when StC_DOF_MODE=1, 2, 3, or 7 and StC_CMODE=4 or 5]
-          1   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} (-)
+          1   StC_SA_MODE   - Semi-Active control mode {1: velocity-based ground hook control; 2: Inverse velocity-based ground hook control; 3: displacement-based ground hook control 4: Phase difference Algorithm with Friction Force 5: Phase difference Algorithm with Damping Force} [used only when StC_CMODE=1]
           0   StC_X_C_HIGH  - StC X high damping for ground hook control
           0   StC_X_C_LOW   - StC X low damping for ground hook control
           0   StC_Y_C_HIGH  - StC Y high damping for ground hook control


### PR DESCRIPTION
This is a small change for the Structural Control (StC) within ServoDyn.

Previously, the Semi_Active control mode (`StC_SA_MODE`) was validated unconditionally internally. Now, there is a new validation logic that checks if `StC_CMODE = 1`. The updated comment reflects this for the user: `[used only when StC_CMODE=1]`